### PR TITLE
Implement add code logic for releases

### DIFF
--- a/components/Account/Account.jsx
+++ b/components/Account/Account.jsx
@@ -3,8 +3,8 @@ import { useUser, useSupabaseClient } from "@supabase/auth-helpers-react"
 import styles from "./Account.module.css"
 import cn from "classnames"
 import Avatar from "@/components/Avatar/Avatar"
-import Releases from "../Releases/Releases"
-import CreateRelease from "../Releases/CreateRelease"
+import Releases from "@/components/Releases/Releases"
+import CreateRelease from "@/components/Releases/CreateRelease"
 
 export default function Account({ session }) {
   const supabase = useSupabaseClient()
@@ -12,7 +12,7 @@ export default function Account({ session }) {
   const [loading, setLoading] = useState(true)
   const [username, setUsername] = useState(null)
   const [avatarUrl, setAvatarUrl] = useState(null)
-  const [createNewRelease, setCreateNewRelease] = useState(false)
+  const [showCreateNewRelease, setShowCreateNewRelease] = useState(false)
 
   useEffect(() => {
     async function getProfile() {
@@ -115,13 +115,16 @@ export default function Account({ session }) {
           {loading ? "Loading..." : "Update"}
         </button>
 
-        {createNewRelease ? (
+        {showCreateNewRelease ? (
           <CreateRelease
             user={user}
-            setCreateNewRelease={setCreateNewRelease}
+            setShowCreateNewRelease={setShowCreateNewRelease}
           />
         ) : (
-          <Releases user={user} setCreateNewRelease={setCreateNewRelease} />
+          <Releases
+            user={user}
+            setShowCreateNewRelease={setShowCreateNewRelease}
+          />
         )}
         <button className="button" onClick={() => supabase.auth.signOut()}>
           Sign Out

--- a/components/AddCodes/AddCodes.jsx
+++ b/components/AddCodes/AddCodes.jsx
@@ -1,0 +1,62 @@
+import { useState, useEffect } from "react"
+import { useSupabaseClient } from "@supabase/auth-helpers-react"
+
+export default function AddCodes({ user_id, release_id, setShowAddCodes }) {
+  const supabase = useSupabaseClient()
+  const [codes, setCodes] = useState()
+  const [codesAdded, setCodesAdded] = useState(false)
+  const [formattedCodes, setFormattedCodes] = useState([])
+
+  async function createCodes() {
+    try {
+      let codeArray = []
+      let newCodes = codes.split(/\s/g)
+      newCodes.forEach((code) => {
+        let newCode = {
+          release_id: release_id,
+          user_id: user_id,
+          code: code,
+        }
+        codeArray.push(newCode)
+      })
+      const { data, error } = await supabase.from("codes").insert(codeArray)
+      if (error) throw error
+
+      setShowAddCodes(false)
+    } catch (error) {
+      alert("Error creating codes!")
+      console.log(error)
+    }
+  }
+
+  return (
+    <div
+      className="stack max-inline"
+      style={{ "--max-inline-size": "var(--input-screen-max-inline-size)" }}
+    >
+      <h3>Add codes</h3>
+
+      <label className="label" htmlFor="codes">
+        Codes
+      </label>
+      <textarea
+        id="albumCodes"
+        placeholder="Enter your codes separated by a space"
+        cols="20"
+        rows="8"
+        onChange={(e) => setCodes(e.target.value)}
+      ></textarea>
+
+      <button className="button" data-variant="primary" onClick={createCodes}>
+        Add
+      </button>
+      <button
+        className="button"
+        data-variant="primary"
+        onClick={() => setShowAddCodes(false)}
+      >
+        Cancel
+      </button>
+    </div>
+  )
+}

--- a/components/AddCodes/AddCodes.jsx
+++ b/components/AddCodes/AddCodes.jsx
@@ -4,8 +4,6 @@ import { useSupabaseClient } from "@supabase/auth-helpers-react"
 export default function AddCodes({ user_id, release_id, setShowAddCodes }) {
   const supabase = useSupabaseClient()
   const [codes, setCodes] = useState()
-  const [codesAdded, setCodesAdded] = useState(false)
-  const [formattedCodes, setFormattedCodes] = useState([])
 
   async function createCodes() {
     try {

--- a/components/AddCodes/AddCodes.jsx
+++ b/components/AddCodes/AddCodes.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react"
 import { useSupabaseClient } from "@supabase/auth-helpers-react"
 
-export default function AddCodes({ user_id, release_id, setShowAddCodes }) {
+export default function AddCodes({ userId, releaseId, setShowAddCodes }) {
   const supabase = useSupabaseClient()
   const [codes, setCodes] = useState()
 
@@ -11,8 +11,8 @@ export default function AddCodes({ user_id, release_id, setShowAddCodes }) {
       let newCodes = codes.split(/\s/g)
       newCodes.forEach((code) => {
         let newCode = {
-          release_id: release_id,
-          user_id: user_id,
+          release_id: releaseId,
+          user_id: userId,
           code: code,
         }
         codeArray.push(newCode)

--- a/components/Releases/CreateRelease.jsx
+++ b/components/Releases/CreateRelease.jsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from "react"
-import { useUser, useSupabaseClient } from "@supabase/auth-helpers-react"
+import { useState } from "react"
+import { useSupabaseClient } from "@supabase/auth-helpers-react"
 
 const releaseTypes = [
   { id: 1, text: "LP" },
@@ -10,7 +10,7 @@ const releaseTypes = [
   { id: 6, text: "Choose release type", isDisabled: true },
 ]
 
-export default function CreateRelease({ user, setCreateNewRelease }) {
+export default function CreateRelease({ user, setShowCreateNewRelease }) {
   const supabase = useSupabaseClient()
   const [title, setTitle] = useState()
   const [artist, setArtist] = useState(
@@ -19,22 +19,22 @@ export default function CreateRelease({ user, setCreateNewRelease }) {
   const [label, setLabel] = useState(
     user.user_metadata.type === "Label" ? user.user_metadata.name : null
   )
-  const [artwork_url, setArtwork_url] = useState()
-  const [download_url, setDownload_url] = useState()
-  const [page_password, setPage_password] = useState()
-  const [is_password_protected, setIs_password_protected] = useState(false)
+  const [artworkUrl, setArtworkUrl] = useState()
+  const [downloadUrl, setDownloadUrl] = useState()
+  const [pagePassword, setPagePassword] = useState()
+  const [isPasswordProtected, setIsPasswordProtected] = useState(false)
   const [type, setType] = useState(releaseTypes[5].text)
 
-  const [user_id, setUser_id] = useState(user.id)
+  const [userId, setUserId] = useState(user.id)
 
   async function createNewRelease({
     title,
     artist,
     label,
-    artwork_url,
-    download_url,
+    artworkUrl,
+    downloadUrl,
     type,
-    user_id,
+    userId,
   }) {
     try {
       let slugger = title.toLowerCase()
@@ -42,8 +42,8 @@ export default function CreateRelease({ user, setCreateNewRelease }) {
         title: title,
         artist: artist,
         label: label,
-        artwork_url: artwork_url,
-        download_url: download_url,
+        artwork_url: artworkUrl,
+        download_url: downloadUrl,
         type: type,
         release_slug: slugger
           .replace(/[^a-z0-9 -]/g, "")
@@ -59,7 +59,7 @@ export default function CreateRelease({ user, setCreateNewRelease }) {
     } catch (error) {
       alert("Error creating new release!")
     } finally {
-      setCreateNewRelease(false)
+      setShowCreateNewRelease(false)
     }
   }
 
@@ -103,26 +103,26 @@ export default function CreateRelease({ user, setCreateNewRelease }) {
         onChange={(e) => setLabel(e.target.value)}
       />
 
-      <label className="label" htmlFor="artwork_url">
+      <label className="label" htmlFor="artworkUrl">
         Artwork
       </label>
       <input
         className="input"
-        id="artwork_url"
+        id="artworkUrl"
         type="text"
-        value={artwork_url || ""}
-        onChange={(e) => setArtwork_url(e.target.value)}
+        value={artworkUrl || ""}
+        onChange={(e) => setArtworkUrl(e.target.value)}
       />
 
-      <label className="label" htmlFor="download_url">
+      <label className="label" htmlFor="downloadUrl">
         Download Url
       </label>
       <input
         className="input"
-        id="download_url"
+        id="downloadUrl"
         type="text"
-        value={download_url || ""}
-        onChange={(e) => setDownload_url(e.target.value)}
+        value={downloadUrl || ""}
+        onChange={(e) => setDownloadUrl(e.target.value)}
       />
 
       <label className="label" htmlFor="type">
@@ -154,9 +154,9 @@ export default function CreateRelease({ user, setCreateNewRelease }) {
             artist,
             label,
             type,
-            artwork_url,
-            download_url,
-            user_id,
+            artworkUrl,
+            downloadUrl,
+            userId,
           })
         }
         disabled={!title || !artist || !type}
@@ -167,7 +167,7 @@ export default function CreateRelease({ user, setCreateNewRelease }) {
       <button
         className="button"
         data-varian="primary"
-        onClick={() => setCreateNewRelease(false)}
+        onClick={() => setShowCreateNewRelease(false)}
       >
         Cancel
       </button>

--- a/components/Releases/ReleaseCard.jsx
+++ b/components/Releases/ReleaseCard.jsx
@@ -1,6 +1,7 @@
 import styles from "./ReleaseCard.module.css"
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import AddCodes from "../AddCodes/AddCodes"
+import { useSupabaseClient } from "@supabase/auth-helpers-react"
 
 export default function ReleaseCard({
   title,
@@ -12,7 +13,29 @@ export default function ReleaseCard({
   release_id,
   user_id,
 }) {
+  const supabase = useSupabaseClient()
   const [showAddCodes, setShowAddCodes] = useState(false)
+  const [codeCount, setCodeCount] = useState(0)
+
+  useEffect(() => {
+    if (!showAddCodes) {
+      getCodeCount()
+    }
+  }, [showAddCodes])
+
+  async function getCodeCount() {
+    try {
+      const { count, error } = await supabase
+        .from("codes")
+        .select("*", { count: "exact", head: true })
+        .eq("release_id", release_id)
+        .eq("redeemed", false)
+      if (error) throw error
+      setCodeCount(count)
+    } catch (error) {
+      throw error
+    }
+  }
   return showAddCodes ? (
     <AddCodes
       user_id={user_id}
@@ -36,6 +59,7 @@ export default function ReleaseCard({
       <h4>{artist}</h4>
       <h5>{label}</h5>
       <h6>{type}</h6>
+      <p>Codes remaining: {`${codeCount}`}</p>
       <button
         type="button"
         data-variant="primary"

--- a/components/Releases/ReleaseCard.jsx
+++ b/components/Releases/ReleaseCard.jsx
@@ -1,4 +1,6 @@
 import styles from "./ReleaseCard.module.css"
+import { useState } from "react"
+import AddCodes from "../AddCodes/AddCodes"
 
 export default function ReleaseCard({
   title,
@@ -7,8 +9,17 @@ export default function ReleaseCard({
   type,
   artwork_url,
   size,
+  release_id,
+  user_id,
 }) {
-  return (
+  const [showAddCodes, setShowAddCodes] = useState(false)
+  return showAddCodes ? (
+    <AddCodes
+      user_id={user_id}
+      release_id={release_id}
+      setShowAddCodes={setShowAddCodes}
+    />
+  ) : (
     <div className="container">
       {artwork_url ? (
         <img
@@ -25,6 +36,13 @@ export default function ReleaseCard({
       <h4>{artist}</h4>
       <h5>{label}</h5>
       <h6>{type}</h6>
+      <button
+        type="button"
+        data-variant="primary"
+        onClick={() => setShowAddCodes(true)}
+      >
+        Add Codes
+      </button>
     </div>
   )
 }

--- a/components/Releases/ReleaseCard.jsx
+++ b/components/Releases/ReleaseCard.jsx
@@ -8,10 +8,10 @@ export default function ReleaseCard({
   artist,
   label,
   type,
-  artwork_url,
+  artworkUrl,
   size,
-  release_id,
-  user_id,
+  releaseId,
+  userId,
 }) {
   const supabase = useSupabaseClient()
   const [showAddCodes, setShowAddCodes] = useState(false)
@@ -28,7 +28,7 @@ export default function ReleaseCard({
       const { count, error } = await supabase
         .from("codes")
         .select("*", { count: "exact", head: true })
-        .eq("release_id", release_id)
+        .eq("release_id", releaseId)
         .eq("redeemed", false)
       if (error) throw error
       setCodeCount(count)
@@ -38,22 +38,22 @@ export default function ReleaseCard({
   }
   return showAddCodes ? (
     <AddCodes
-      user_id={user_id}
-      release_id={release_id}
+      userId={userId}
+      releaseId={releaseId}
       setShowAddCodes={setShowAddCodes}
     />
   ) : (
     <div className="container">
-      {artwork_url ? (
+      {artworkUrl ? (
         <img
           className={styles.image}
-          src={artwork_url}
+          src={artworkUrl}
           alt=""
           height={size}
           width={size}
         />
       ) : (
-        <div style={{ height: size, width: size }} />
+        <div className={styles.image} />
       )}
       <h3>{title}</h3>
       <h4>{artist}</h4>

--- a/components/Releases/Releases.jsx
+++ b/components/Releases/Releases.jsx
@@ -2,12 +2,14 @@ import { useState, useEffect } from "react"
 import { useSupabaseClient } from "@supabase/auth-helpers-react"
 import ReleaseCard from "./ReleaseCard"
 import { useRouter } from "next/router"
+import AddCodes from "../AddCodes/AddCodes"
 
 export default function Releases({ user, setCreateNewRelease }) {
   const supabase = useSupabaseClient()
   const router = useRouter()
   const [loading, setLoading] = useState(true)
   const [releases, setReleases] = useState([])
+  const [showAddCodes, setShowAddCodes] = useState(false)
 
   useEffect(() => {
     async function getReleases() {
@@ -53,10 +55,7 @@ export default function Releases({ user, setCreateNewRelease }) {
 
       <ul>
         {releases.map((release) => (
-          <li
-            key={release.id}
-            onClick={() => router.push(`/releases/${release.release_slug}`)}
-          >
+          <li key={release.id}>
             <ReleaseCard
               title={release.title}
               artist={release.artist}
@@ -64,6 +63,8 @@ export default function Releases({ user, setCreateNewRelease }) {
               type={release.type}
               artwork_url={release.artwork_url}
               size={250}
+              release_id={release.id}
+              user_id={user.id}
             />
           </li>
         ))}

--- a/components/Releases/Releases.jsx
+++ b/components/Releases/Releases.jsx
@@ -3,15 +3,13 @@ import { useSupabaseClient } from "@supabase/auth-helpers-react"
 import ReleaseCard from "./ReleaseCard"
 import { useRouter } from "next/router"
 
-export default function Releases({ user, setCreateNewRelease }) {
+export default function Releases({ user, setShowCreateNewRelease }) {
   const supabase = useSupabaseClient()
   const [releases, setReleases] = useState([])
 
   useEffect(() => {
     async function getReleases() {
       try {
-        setLoading(true)
-
         let { data, error } = await supabase
           .from("releases")
           .select("*")
@@ -27,8 +25,6 @@ export default function Releases({ user, setCreateNewRelease }) {
       } catch (error) {
         alert("Error loading user releases!")
         console.log(error)
-      } finally {
-        setLoading(false)
       }
     }
 
@@ -44,12 +40,12 @@ export default function Releases({ user, setCreateNewRelease }) {
       <button
         className="button"
         data-variant="primary"
-        onClick={() => setCreateNewRelease(true)}
+        onClick={() => setShowCreateNewRelease(true)}
       >
         Create
       </button>
 
-      <ul>
+      <ul role="list">
         {releases.map((release) => (
           <li key={release.id}>
             <ReleaseCard
@@ -57,10 +53,10 @@ export default function Releases({ user, setCreateNewRelease }) {
               artist={release.artist}
               label={release.label}
               type={release.type}
-              artwork_url={release.artwork_url}
+              artworkUrl={release.artwork_url}
               size={250}
-              release_id={release.id}
-              user_id={user.id}
+              releaseId={release.id}
+              userId={user.id}
             />
           </li>
         ))}

--- a/components/Releases/Releases.jsx
+++ b/components/Releases/Releases.jsx
@@ -2,14 +2,10 @@ import { useState, useEffect } from "react"
 import { useSupabaseClient } from "@supabase/auth-helpers-react"
 import ReleaseCard from "./ReleaseCard"
 import { useRouter } from "next/router"
-import AddCodes from "../AddCodes/AddCodes"
 
 export default function Releases({ user, setCreateNewRelease }) {
   const supabase = useSupabaseClient()
-  const router = useRouter()
-  const [loading, setLoading] = useState(true)
   const [releases, setReleases] = useState([])
-  const [showAddCodes, setShowAddCodes] = useState(false)
 
   useEffect(() => {
     async function getReleases() {

--- a/pages/releases/[slug].js
+++ b/pages/releases/[slug].js
@@ -1,5 +1,6 @@
 import { supabase } from "@/utils/supabase"
 import ReleaseLayout from "@/components/Releases/ReleaseLayout"
+
 export async function getServerSideProps({ params }) {
   let { data: release, error } = await supabase
     .from("releases")

--- a/styles/reset.css
+++ b/styles/reset.css
@@ -50,6 +50,7 @@ h6 {
   isolation: isolate;
 }
 
-ul {
+ul[role="list"],
+ol[role="list"] {
   list-style: none;
 }


### PR DESCRIPTION
This pull request implements the add code logic to releases.

On user dashboard, you can now click on "add codes" button to bring up a text box where you can add your codes separated by at least one space.

Once added, the code count for that release will update showing you available codes for that release. (I think there might be a better way to do this. I am still thinking out the logic.)