### PR TITLE
Misc updates including getting codes for release

### DIFF
--- a/components/Account/Account.jsx
+++ b/components/Account/Account.jsx
@@ -28,7 +28,7 @@ export default function Account({ session }) {
         }
 
         if (data) {
-          setUsername(data.name)
+          setUsername(data.username)
           setAvatarUrl(data.avatar_url)
         }
       } catch (error) {
@@ -48,9 +48,9 @@ export default function Account({ session }) {
 
       const updates = {
         id: user.id,
-        name: username,
-        avatar: avatarUrl,
-        // updated_at: new Date().toISOString(),
+        username: username,
+        avatar_url: avatarUrl,
+        updated_at: new Date().toISOString(),
       }
 
       let { error } = await supabase.from("profiles").upsert(updates)

--- a/components/AddCodes/AddCodes.jsx
+++ b/components/AddCodes/AddCodes.jsx
@@ -7,7 +7,7 @@ import {
   DialogClose,
 } from "@/components/Dialog/Dialog"
 
-export default function AddCodes({ userId, releaseId }) {
+export default function AddCodes({ userId, releaseId, setUpdateCodeCount }) {
   const supabase = useSupabaseClient()
   const [codes, setCodes] = useState()
   const [open, setOpen] = useState(false)
@@ -32,6 +32,7 @@ export default function AddCodes({ userId, releaseId }) {
       console.log(error)
     } finally {
       console.log("All done!")
+      setUpdateCodeCount(true)
       setOpen(false)
     }
   }

--- a/components/AddCodes/AddCodes.jsx
+++ b/components/AddCodes/AddCodes.jsx
@@ -7,7 +7,7 @@ import {
   DialogClose,
 } from "@/components/Dialog/Dialog"
 
-export default function AddCodes({ userId, releaseId, setUpdateCodeCount }) {
+export default function AddCodes({ userId, releaseId, setOnCodeAdded }) {
   const supabase = useSupabaseClient()
   const [codes, setCodes] = useState()
   const [open, setOpen] = useState(false)
@@ -32,7 +32,7 @@ export default function AddCodes({ userId, releaseId, setUpdateCodeCount }) {
       console.log(error)
     } finally {
       console.log("All done!")
-      setUpdateCodeCount(true)
+      setOnCodeAdded(true)
       setOpen(false)
     }
   }

--- a/components/AddCodes/AddCodes.jsx
+++ b/components/AddCodes/AddCodes.jsx
@@ -1,9 +1,16 @@
 import { useState, useEffect } from "react"
 import { useSupabaseClient } from "@supabase/auth-helpers-react"
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogClose,
+} from "@/components/Dialog/Dialog"
 
-export default function AddCodes({ userId, releaseId, setShowAddCodes }) {
+export default function AddCodes({ userId, releaseId }) {
   const supabase = useSupabaseClient()
   const [codes, setCodes] = useState()
+  const [open, setOpen] = useState(false)
 
   async function createCodes() {
     try {
@@ -19,42 +26,52 @@ export default function AddCodes({ userId, releaseId, setShowAddCodes }) {
       })
       const { data, error } = await supabase.from("codes").insert(codeArray)
       if (error) throw error
-
-      setShowAddCodes(false)
+      alert("New codes added!")
     } catch (error) {
       alert("Error creating codes!")
       console.log(error)
+    } finally {
+      console.log("All done!")
+      setOpen(false)
     }
   }
 
   return (
-    <div
-      className="stack max-inline"
-      style={{ "--max-inline-size": "var(--input-screen-max-inline-size)" }}
-    >
-      <h3>Add codes</h3>
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger className="button" data-variant="primary">
+        Add codes
+      </DialogTrigger>
 
-      <label className="label" htmlFor="codes">
-        Codes
-      </label>
-      <textarea
-        id="albumCodes"
-        placeholder="Enter your codes separated by a space"
-        cols="20"
-        rows="8"
-        onChange={(e) => setCodes(e.target.value)}
-      ></textarea>
+      <DialogContent>
+        <header>
+          <h3>Add codes</h3>
+        </header>
 
-      <button className="button" data-variant="primary" onClick={createCodes}>
-        Add
-      </button>
-      <button
-        className="button"
-        data-variant="primary"
-        onClick={() => setShowAddCodes(false)}
-      >
-        Cancel
-      </button>
-    </div>
+        <div className="stack overflow-y">
+          <label className="label" htmlFor="codes">
+            Codes
+          </label>
+          <textarea
+            id="albumCodes"
+            placeholder="Enter your codes separated by a space"
+            cols="20"
+            rows="8"
+            onChange={(e) => setCodes(e.target.value)}
+          ></textarea>
+        </div>
+
+        <footer className="button-actions block-wrap">
+          <button
+            className="button"
+            data-variant="primary"
+            onClick={createCodes}
+          >
+            Add
+          </button>
+
+          <DialogClose className="button">Cancel</DialogClose>
+        </footer>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/components/AddCodes/AddCodes.jsx
+++ b/components/AddCodes/AddCodes.jsx
@@ -15,6 +15,7 @@ export default function AddCodes({ userId, releaseId, setOnCodeAdded }) {
   async function createCodes() {
     try {
       let codeArray = []
+
       let newCodes = codes.split(/\s/g)
       newCodes.forEach((code) => {
         let newCode = {
@@ -24,15 +25,17 @@ export default function AddCodes({ userId, releaseId, setOnCodeAdded }) {
         }
         codeArray.push(newCode)
       })
+
       const { data, error } = await supabase.from("codes").insert(codeArray)
       if (error) throw error
       alert("New codes added!")
+      setOnCodeAdded(true)
     } catch (error) {
       alert("Error creating codes!")
       console.log(error)
     } finally {
       console.log("All done!")
-      setOnCodeAdded(true)
+
       setOpen(false)
     }
   }

--- a/components/CodeGenerator/CodeGenerator.jsx
+++ b/components/CodeGenerator/CodeGenerator.jsx
@@ -35,7 +35,7 @@ export default function CodeGenerator({ releaseId }) {
     setCode(activeCodes[rng])
     const { data, error } = await supabase
       .from("codes")
-      .update({ redeemed: true, redeemed_at: new Date() })
+      .update({ redeemed: true, redeemed_at: new Date().toISOString() })
       .eq("id", activeCodes[rng].id)
   }
 

--- a/components/CodeGenerator/CodeGenerator.jsx
+++ b/components/CodeGenerator/CodeGenerator.jsx
@@ -1,0 +1,85 @@
+import { useState, useEffect } from "react"
+import { useSupabaseClient } from "@supabase/auth-helpers-react"
+import Link from "next/link"
+
+export default function CodeGenerator({ releaseId }) {
+  const supabase = useSupabaseClient()
+  const [activeCodes, setActiveCodes] = useState([])
+  const [code, setCode] = useState()
+  const [copiedToClipboard, setCopiedToClipboard] = useState(false)
+
+  useEffect(() => {
+    async function getActiveCodes() {
+      try {
+        let { data, error } = await supabase
+          .from("codes")
+          .select("*")
+          .eq("release_id", releaseId)
+          .eq("redeemed", false)
+
+        if (error) throw error
+
+        if (data) {
+          setActiveCodes(data)
+        }
+      } catch (error) {
+        alert("Error loading codes!")
+        console.log(error)
+      }
+    }
+    getActiveCodes()
+  }, [supabase, releaseId])
+
+  async function getRandomCode() {
+    let rng = Math.floor(Math.random() * activeCodes.length)
+    setCode(activeCodes[rng])
+    const { data, error } = await supabase
+      .from("codes")
+      .update({ redeemed: true, redeemed_at: new Date() })
+      .eq("id", activeCodes[rng].id)
+  }
+
+  async function copyToClipboard(code) {
+    if ("clipboard" in navigator) {
+      setCopiedToClipboard(true)
+      return await navigator.clipboard.writeText(code)
+    } else {
+      setCopiedToClipboard(true)
+      return document.execCommand("copy", true, code)
+    }
+  }
+
+  return activeCodes ? (
+    <div>
+      {code ? (
+        <>
+          <p>{code.code}</p>
+          {copiedToClipboard ? (
+            <button type="button" data-variant="primary" disabled>
+              Copied!
+            </button>
+          ) : (
+            <button
+              type="button"
+              data-variant="primary"
+              onClick={() => copyToClipboard(code.code)}
+            >
+              Copy Code
+            </button>
+          )}
+          <a href="https://bandcamp.com">Redeem</a>
+        </>
+      ) : (
+        <button
+          type="button"
+          data-variant="primary"
+          onClick={() => getRandomCode()}
+        >
+          Get Random Code
+        </button>
+      )}
+    </div>
+  ) : (
+    <p>No Codes for this release</p>
+  )
+}

--- a/components/Releases/CreateRelease.jsx
+++ b/components/Releases/CreateRelease.jsx
@@ -17,7 +17,7 @@ const releaseTypes = [
   { id: 6, text: "Choose release type", isDisabled: true },
 ]
 
-export default function CreateRelease({ setOnReleaseCreated }) {
+export default function CreateRelease() {
   const user = useUser()
   const supabase = useSupabaseClient()
   const [open, setOpen] = useState(false)
@@ -62,7 +62,7 @@ export default function CreateRelease({ setOnReleaseCreated }) {
       alert("Error creating new release!")
     } finally {
       console.log("All done!")
-      setOnReleaseCreated(true)
+
       setOpen(false)
     }
   }

--- a/components/Releases/CreateRelease.jsx
+++ b/components/Releases/CreateRelease.jsx
@@ -17,7 +17,7 @@ const releaseTypes = [
   { id: 6, text: "Choose release type", isDisabled: true },
 ]
 
-export default function CreateRelease() {
+export default function CreateRelease({ setUpdateReleases }) {
   const user = useUser()
   const supabase = useSupabaseClient()
   const [open, setOpen] = useState(false)
@@ -62,6 +62,7 @@ export default function CreateRelease() {
       alert("Error creating new release!")
     } finally {
       console.log("All done!")
+      setUpdateReleases(true)
       setOpen(false)
     }
   }

--- a/components/Releases/CreateRelease.jsx
+++ b/components/Releases/CreateRelease.jsx
@@ -17,7 +17,7 @@ const releaseTypes = [
   { id: 6, text: "Choose release type", isDisabled: true },
 ]
 
-export default function CreateRelease({ setUpdateReleases }) {
+export default function CreateRelease({ setOnReleaseCreated }) {
   const user = useUser()
   const supabase = useSupabaseClient()
   const [open, setOpen] = useState(false)
@@ -62,7 +62,7 @@ export default function CreateRelease({ setUpdateReleases }) {
       alert("Error creating new release!")
     } finally {
       console.log("All done!")
-      setUpdateReleases(true)
+      setOnReleaseCreated(true)
       setOpen(false)
     }
   }

--- a/components/Releases/ReleaseCard.jsx
+++ b/components/Releases/ReleaseCard.jsx
@@ -16,7 +16,7 @@ export default function ReleaseCard({
 }) {
   const supabase = useSupabaseClient()
   const [codeCount, setCodeCount] = useState(0)
-  const [updateCodeCount, setUpdateCodeCount] = useState(true)
+  const [onCodeAdded, setOnCodeAdded] = useState(true)
 
   useEffect(() => {
     async function getCodeCount() {
@@ -34,9 +34,9 @@ export default function ReleaseCard({
     }
     if (updateCodeCount) {
       getCodeCount()
-      setUpdateCodeCount(false)
+      setOnCodeAdded(false)
     }
-  }, [setCodeCount, supabase, releaseId, updateCodeCount])
+  }, [setCodeCount, supabase, releaseId, onCodeAdded])
 
   return (
     <div className={cn(styles.component, "container")}>
@@ -61,7 +61,7 @@ export default function ReleaseCard({
         <AddCodes
           userId={userId}
           releaseId={releaseId}
-          setUpdateCodeCount={setUpdateCodeCount}
+          setOnCodeAdded={setOnCodeAdded}
         />
       </div>
     </div>

--- a/components/Releases/ReleaseCard.jsx
+++ b/components/Releases/ReleaseCard.jsx
@@ -16,6 +16,7 @@ export default function ReleaseCard({
 }) {
   const supabase = useSupabaseClient()
   const [codeCount, setCodeCount] = useState(0)
+  const [updateCodeCount, setUpdateCodeCount] = useState(true)
 
   useEffect(() => {
     async function getCodeCount() {
@@ -31,9 +32,11 @@ export default function ReleaseCard({
         throw error
       }
     }
-
-    getCodeCount()
-  }, [setCodeCount, supabase, releaseId])
+    if (updateCodeCount) {
+      getCodeCount()
+      setUpdateCodeCount(false)
+    }
+  }, [setCodeCount, supabase, releaseId, updateCodeCount])
 
   return (
     <div className={cn(styles.component, "container")}>
@@ -55,7 +58,11 @@ export default function ReleaseCard({
         <h5>{label}</h5>
         <h6>{type}</h6>
         <p>Codes remaining: {`${codeCount}`}</p>
-        <AddCodes userId={userId} releaseId={releaseId} />
+        <AddCodes
+          userId={userId}
+          releaseId={releaseId}
+          setUpdateCodeCount={setUpdateCodeCount}
+        />
       </div>
     </div>
   )

--- a/components/Releases/ReleaseCard.jsx
+++ b/components/Releases/ReleaseCard.jsx
@@ -32,11 +32,47 @@ export default function ReleaseCard({
         throw error
       }
     }
-    if (updateCodeCount) {
+    if (onCodeAdded) {
       getCodeCount()
       setOnCodeAdded(false)
     }
   }, [setCodeCount, supabase, releaseId, onCodeAdded])
+
+  // const newCodes = supabase
+  //   .channel("new-codes-added")
+  //   .on(
+  //     "postgres_changes",
+  //     {
+  //       event: "INSERT",
+  //       schema: "public",
+  //       table: "codes",
+  //     },
+  //     (payload) => {
+  //       console.log("payload: ", payload)
+  //       console.log("releseId: ", releaseId)
+  //       if (payload.new.release_id === releaseId) {
+  //         let count = codeCount
+  //         setCodeCount(count + 1)
+  //       }
+  //     }
+  //   )
+  //   .on(
+  //     "postgres_changes",
+  //     {
+  //       event: "UPDATE",
+  //       schema: "public",
+  //       table: "codes",
+  //     },
+  //     (payload) => {
+  //       if (
+  //         payload.new.release_id === releaseId &&
+  //         payload.new.redeemed === true
+  //       ) {
+  //         setCodeCount(codeCount - 1)
+  //       }
+  //     }
+  //   )
+  //   .subscribe()
 
   return (
     <div className={cn(styles.component, "container")}>

--- a/components/Releases/ReleaseCard.jsx
+++ b/components/Releases/ReleaseCard.jsx
@@ -15,7 +15,6 @@ export default function ReleaseCard({
   userId,
 }) {
   const supabase = useSupabaseClient()
-  const [showAddCodes, setShowAddCodes] = useState(false)
   const [codeCount, setCodeCount] = useState(0)
 
   useEffect(() => {
@@ -33,18 +32,10 @@ export default function ReleaseCard({
       }
     }
 
-    if (!showAddCodes) {
-      getCodeCount()
-    }
-  }, [showAddCodes, setCodeCount, supabase, releaseId])
+    getCodeCount()
+  }, [setCodeCount, supabase, releaseId])
 
-  return showAddCodes ? (
-    <AddCodes
-      userId={userId}
-      releaseId={releaseId}
-      setShowAddCodes={setShowAddCodes}
-    />
-  ) : (
+  return (
     <div className={cn(styles.component, "container")}>
       {artworkUrl ? (
         <img
@@ -64,13 +55,7 @@ export default function ReleaseCard({
         <h5>{label}</h5>
         <h6>{type}</h6>
         <p>Codes remaining: {`${codeCount}`}</p>
-        <button
-          type="button"
-          data-variant="primary"
-          onClick={() => setShowAddCodes(true)}
-        >
-          Add Codes
-        </button>
+        <AddCodes userId={userId} releaseId={releaseId} />
       </div>
     </div>
   )

--- a/components/Releases/ReleaseLayout.jsx
+++ b/components/Releases/ReleaseLayout.jsx
@@ -1,23 +1,25 @@
-export default function ReleaseLayout({
-  title,
-  artist,
-  label,
-  artwork_url,
-  download_url,
-  type,
-}) {
+import CodeGenerator from "../CodeGenerator/CodeGenerator"
+
+export default function ReleaseLayout({ release }) {
   return (
     <div
       className="stack max-inline"
       style={{ "--max-inline-size": "var(--input-screen-max-inline-size" }}
     >
-      {artwork_url ? (
-        <img src={artwork_url} alt={title} height={250} width={250} />
+      {release.artwork_url ? (
+        <img
+          src={release.artwork_url}
+          alt={release.title}
+          height={250}
+          width={250}
+        />
       ) : null}
-      <h1>{title}</h1>
-      <h2>{artist}</h2>
-      <h3>{label}</h3>
-      <h4>{type}</h4>
+      <h1>{release.title}</h1>
+      <h2>{release.artist}</h2>
+      <h3>{release.label}</h3>
+      <h4>{release.type}</h4>
+
+      <CodeGenerator releaseId={release.id} />
     </div>
   )
 }

--- a/components/Releases/Releases.jsx
+++ b/components/Releases/Releases.jsx
@@ -7,7 +7,7 @@ export default function Releases() {
   const supabase = useSupabaseClient()
   const user = useUser()
   const [releases, setReleases] = useState([])
-  const [updateReleases, setUpdateReleases] = useState(true)
+  const [onReleaseCreated, setOnReleaseCreated] = useState(true)
 
   useEffect(() => {
     async function getReleases() {
@@ -31,9 +31,9 @@ export default function Releases() {
     }
     if (updateReleases) {
       getReleases()
-      setUpdateReleases(false)
+      setOnReleaseCreated(false)
     }
-  }, [supabase, user.id, updateReleases])
+  }, [supabase, user.id, onReleaseCreated])
 
   // const newReleases = supabase
   //   .channel("any")
@@ -58,7 +58,7 @@ export default function Releases() {
       <hr></hr>
       <h2>Releases</h2>
 
-      <CreateRelease setUpdateReleases={setUpdateReleases} />
+      <CreateRelease setOnReleaseCreated={setOnReleaseCreated} />
 
       <ul className="stack" role="list">
         {releases.map((release) => (

--- a/components/Releases/Releases.jsx
+++ b/components/Releases/Releases.jsx
@@ -32,6 +32,21 @@ export default function Releases() {
     getReleases()
   }, [supabase, user.id])
 
+  // const newReleases = supabase
+  //   .channel("any")
+  //   .on(
+  //     "postgres_changes",
+  //     {
+  //       event: "INSERT",
+  //       schema: "public",
+  //       table: "releases",
+  //     },
+  //     (payload) => console.log("data: ", payload)
+  //   )
+  //   .subscribe()
+
+  // console.log("new release: ", newReleases)
+
   return (
     <section
       className="stack max-inline"

--- a/components/Releases/Releases.jsx
+++ b/components/Releases/Releases.jsx
@@ -7,6 +7,7 @@ export default function Releases() {
   const supabase = useSupabaseClient()
   const user = useUser()
   const [releases, setReleases] = useState([])
+  const [updateReleases, setUpdateReleases] = useState(true)
 
   useEffect(() => {
     async function getReleases() {
@@ -28,9 +29,11 @@ export default function Releases() {
         console.log(error)
       }
     }
-
-    getReleases()
-  }, [supabase, user.id])
+    if (updateReleases) {
+      getReleases()
+      setUpdateReleases(false)
+    }
+  }, [supabase, user.id, updateReleases])
 
   // const newReleases = supabase
   //   .channel("any")
@@ -55,7 +58,7 @@ export default function Releases() {
       <hr></hr>
       <h2>Releases</h2>
 
-      <CreateRelease />
+      <CreateRelease setUpdateReleases={setUpdateReleases} />
 
       <ul className="stack" role="list">
         {releases.map((release) => (

--- a/pages/releases/[slug].js
+++ b/pages/releases/[slug].js
@@ -12,16 +12,5 @@ export async function getServerSideProps({ params }) {
 }
 
 export default function ReleasePage({ release }) {
-  return release ? (
-    <ReleaseLayout
-      title={release.title}
-      artist={release.artist}
-      label={release.label}
-      artwork_url={release.artwork_url}
-      type={release.type}
-      download_url={release.download_url}
-    />
-  ) : (
-    <div>Loading...</div>
-  )
+  return release ? <ReleaseLayout release={release} /> : <div>Loading...</div>
 }

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -33,8 +33,8 @@ const Signup = () => {
       options: {
         data: {
           type: newUser.type,
-          name: newUser.name,
-          avatar: newUser.avatar_url,
+          username: newUser.name,
+          avatar_url: newUser.avatar,
           location: newUser.location,
           slug: slugger
             .replace(/[^a-z0-9 -]/g, "")


### PR DESCRIPTION
This is a multi part PR.

1. Database fields for profiles has been updated. name -> username, avatar -> avatar_url. updated_at created
2. Created the code generator. This currently lives on the releases/[slug] page. My thought process is that in a future update, we can have the releases show on the label and artist pages that will link them to the release page to grab a code. Right now, the redeem link just directs them to bandcamp. We will change this to actually just be a link to download the release.
3. Created a model for add codes to releases.
4. created a new piece of state in Releases and ReleaseCard that updates the user page releases and code counts for each release. This is just a temp fix for this issue. I believe that supabase subscriptions will be the way to go, as this currently creates way too many database calls.