### PR TITLE
Refactor Releases, ReleaseCard, and AddCodes

### DIFF
--- a/components/AddCodes/AddCodes.jsx
+++ b/components/AddCodes/AddCodes.jsx
@@ -7,7 +7,7 @@ import {
   DialogClose,
 } from "@/components/Dialog/Dialog"
 
-export default function AddCodes({ userId, releaseId }) {
+export default function AddCodes({ userId, releaseId, setOnCodeAdded }) {
   const supabase = useSupabaseClient()
   const [codes, setCodes] = useState()
   const [open, setOpen] = useState(false)
@@ -29,6 +29,7 @@ export default function AddCodes({ userId, releaseId }) {
       const { data, error } = await supabase.from("codes").insert(codeArray)
       if (error) throw error
       alert("New codes added!")
+      setOnCodeAdded(true)
     } catch (error) {
       alert("Error creating codes!")
       console.log(error)

--- a/components/AddCodes/AddCodes.jsx
+++ b/components/AddCodes/AddCodes.jsx
@@ -7,7 +7,7 @@ import {
   DialogClose,
 } from "@/components/Dialog/Dialog"
 
-export default function AddCodes({ userId, releaseId, setOnCodeAdded }) {
+export default function AddCodes({ userId, releaseId }) {
   const supabase = useSupabaseClient()
   const [codes, setCodes] = useState()
   const [open, setOpen] = useState(false)
@@ -29,7 +29,6 @@ export default function AddCodes({ userId, releaseId, setOnCodeAdded }) {
       const { data, error } = await supabase.from("codes").insert(codeArray)
       if (error) throw error
       alert("New codes added!")
-      setOnCodeAdded(true)
     } catch (error) {
       alert("Error creating codes!")
       console.log(error)

--- a/components/Releases/ReleaseCard.jsx
+++ b/components/Releases/ReleaseCard.jsx
@@ -13,30 +13,32 @@ export default function ReleaseCard({
   size,
   releaseId,
   userId,
+  releaseCodes,
 }) {
   const supabase = useSupabaseClient()
   const [codeCount, setCodeCount] = useState(0)
-  const [onCodeAdded, setOnCodeAdded] = useState(true)
+  // const [onCodeAdded, setOnCodeAdded] = useState(true)
+  // const [availableCodes, setAvailableCodes] = useState()
 
-  useEffect(() => {
-    async function getCodeCount() {
-      try {
-        const { count, error } = await supabase
-          .from("codes")
-          .select("*", { count: "exact", head: true })
-          .eq("release_id", releaseId)
-          .eq("redeemed", false)
-        if (error) throw error
-        setCodeCount(count)
-      } catch (error) {
-        throw error
-      }
-    }
-    if (onCodeAdded) {
-      getCodeCount()
-      setOnCodeAdded(false)
-    }
-  }, [setCodeCount, supabase, releaseId, onCodeAdded])
+  // useEffect(() => {
+  //   async function getCodeCount() {
+  //     try {
+  //       const { count, error } = await supabase
+  //         .from("codes")
+  //         .select("*", { count: "exact", head: true })
+  //         .eq("release_id", releaseId)
+  //         .eq("redeemed", false)
+  //       if (error) throw error
+  //       setCodeCount(count)
+  //     } catch (error) {
+  //       throw error
+  //     }
+  //   }
+  //   if (onCodeAdded) {
+  //     getCodeCount()
+  //     setOnCodeAdded(false)
+  //   }
+  // }, [setCodeCount, supabase, releaseId, onCodeAdded])
 
   // const newCodes = supabase
   //   .channel("new-codes-added")
@@ -72,10 +74,23 @@ export default function ReleaseCard({
   //       }
   //     }
   //   )
-  //   .subscribe()
+  // .subscribe()
+  useEffect(() => {
+    let availableCodes = []
+    if (releaseCodes) {
+      releaseCodes.forEach((code) => {
+        if (code.redeemed === false) {
+          availableCodes.push(code)
+        }
+      })
+    }
 
+    if (availableCodes.length > 0) {
+      setCodeCount(availableCodes.length)
+    }
+  }, [])
   return (
-    <div className={cn(styles.component, "container")}>
+    <li className={cn(styles.component, "container")}>
       {artworkUrl ? (
         <img
           className={styles.image}
@@ -93,13 +108,9 @@ export default function ReleaseCard({
         <h4>{artist}</h4>
         <h5>{label}</h5>
         <h6>{type}</h6>
-        <p>Codes remaining: {`${codeCount}`}</p>
-        <AddCodes
-          userId={userId}
-          releaseId={releaseId}
-          setOnCodeAdded={setOnCodeAdded}
-        />
+        <p>Codes remaining: {codeCount}</p>
+        <AddCodes userId={userId} releaseId={releaseId} />
       </div>
-    </div>
+    </li>
   )
 }

--- a/components/Releases/ReleaseCard.jsx
+++ b/components/Releases/ReleaseCard.jsx
@@ -17,29 +17,29 @@ export default function ReleaseCard({
 }) {
   const supabase = useSupabaseClient()
   const [codeCount, setCodeCount] = useState(0)
-  // const [onCodeAdded, setOnCodeAdded] = useState(true)
-  // const [availableCodes, setAvailableCodes] = useState()
+  const [onCodeAdded, setOnCodeAdded] = useState(true)
+  const [availableCodes, setAvailableCodes] = useState()
 
-  // useEffect(() => {
-  //   async function getCodeCount() {
-  //     try {
-  //       const { count, error } = await supabase
-  //         .from("codes")
-  //         .select("*", { count: "exact", head: true })
-  //         .eq("release_id", releaseId)
-  //         .eq("redeemed", false)
-  //       if (error) throw error
-  //       setCodeCount(count)
-  //     } catch (error) {
-  //       throw error
-  //     }
-  //   }
-  //   if (onCodeAdded) {
-  //     getCodeCount()
-  //     setOnCodeAdded(false)
-  //   }
-  // }, [setCodeCount, supabase, releaseId, onCodeAdded])
-
+  useEffect(() => {
+    async function getCodeCount() {
+      try {
+        const { count, error } = await supabase
+          .from("codes")
+          .select("*", { count: "exact", head: true })
+          .eq("release_id", releaseId)
+          .eq("redeemed", false)
+        if (error) throw error
+        setCodeCount(count)
+      } catch (error) {
+        throw error
+      }
+    }
+    if (onCodeAdded) {
+      getCodeCount()
+      setOnCodeAdded(false)
+    }
+  }, [setCodeCount, supabase, releaseId, onCodeAdded])
+  // console.log("release Id 1: ", releaseId)
   // const newCodes = supabase
   //   .channel("new-codes-added")
   //   .on(
@@ -51,7 +51,7 @@ export default function ReleaseCard({
   //     },
   //     (payload) => {
   //       console.log("payload: ", payload)
-  //       console.log("releseId: ", releaseId)
+  //       console.log("release Id 2: ", releaseId)
   //       if (payload.new.release_id === releaseId) {
   //         let count = codeCount
   //         setCodeCount(count + 1)
@@ -75,20 +75,22 @@ export default function ReleaseCard({
   //     }
   //   )
   // .subscribe()
-  useEffect(() => {
-    let availableCodes = []
-    if (releaseCodes) {
-      releaseCodes.forEach((code) => {
-        if (code.redeemed === false) {
-          availableCodes.push(code)
-        }
-      })
-    }
+  // useEffect(() => {
+  //   let availableCodes = []
+  //   if (releaseCodes) {
+  //     releaseCodes.forEach((code) => {
+  //       if (code.redeemed === false) {
+  //         availableCodes.push(code)
+  //       }
+  //     })
+  //   }
 
-    if (availableCodes.length > 0) {
-      setCodeCount(availableCodes.length)
-    }
-  }, [])
+  //   if (availableCodes.length > 0) {
+  //     setCodeCount(availableCodes.length)
+  //   }
+  // }, [])
+
+  // console.log("release Id 3: ", releaseId)
   return (
     <li className={cn(styles.component, "container")}>
       {artworkUrl ? (
@@ -109,7 +111,11 @@ export default function ReleaseCard({
         <h5>{label}</h5>
         <h6>{type}</h6>
         <p>Codes remaining: {codeCount}</p>
-        <AddCodes userId={userId} releaseId={releaseId} />
+        <AddCodes
+          userId={userId}
+          releaseId={releaseId}
+          setOnCodeAdded={setOnCodeAdded}
+        />
       </div>
     </li>
   )

--- a/components/Releases/Releases.jsx
+++ b/components/Releases/Releases.jsx
@@ -6,7 +6,6 @@ import CreateRelease from "./CreateRelease"
 export default function Releases() {
   const supabase = useSupabaseClient()
   const user = useUser()
-  const userId = user.id
   const [releases, setReleases] = useState([])
 
   useEffect(() => {
@@ -14,7 +13,7 @@ export default function Releases() {
       try {
         let { data, error } = await supabase
           .from("releases")
-          .select("*")
+          .select("*, codes (*)")
           .eq("user_id", user.id)
 
         if (error) {
@@ -45,7 +44,8 @@ export default function Releases() {
       (payload) => {
         if (payload.new.user_id === user.id) {
           const newRelease = payload.new
-          setReleases({ ...releases, newRelease })
+
+          setReleases([...releases, newRelease])
         }
       }
     )
@@ -73,6 +73,7 @@ export default function Releases() {
             size={250}
             releaseId={release.id}
             userId={user.id}
+            releaseCodes={release.codes}
           />
         ))}
       </ul>

--- a/components/Releases/Releases.jsx
+++ b/components/Releases/Releases.jsx
@@ -15,6 +15,7 @@ export default function Releases() {
           .from("releases")
           .select("*, codes (*)")
           .eq("user_id", user.id)
+          .eq("codes.redeemed", "false")
 
         if (error) {
           throw error


### PR DESCRIPTION
This PR simplifies the logic when displaying releases on user dashboard.

getReleases() will now make one call to the db and grab all user's releases, as well as all codes that have yet to be redeemed for each release. We might want to discuss this, as it might be beneficial to have all of the codes, redeemed or not, for data analysis purposes.

The releases will also now auto update on creation of a new release. This was achieved by subscribing to the INSERT event of a release. We should monitor this, as I'm not sure this is better or safer than doing another API call.

The ReleaseCard has been updated to reflect the changes in getRelease(). It now also receives all of the unused codes for the release. Unfortunately, I can't get a similar result when subscribing to the INSERT event of a code. Because of this, the codes update by doing an API call on codes added. But again, this might be the best way to do this.

The benefit to having the subscriptions working, is that the user would be able to see the codes being redeemed in real time on their dashboard, and that would be a pretty cool feature.

Also fixed the releases.map is not a function error.