### PR TITLE
Add codes now accepts CSV files

### DIFF
--- a/components/Account/Account.jsx
+++ b/components/Account/Account.jsx
@@ -45,8 +45,6 @@ export default function Account({ session }) {
     return <p>Loading...</p>
   }
 
-  console.log("profile data: ", profileData)
-
   return (
     <>
       {!showUpdateView ? (

--- a/components/AddCodes/AddCodes.jsx
+++ b/components/AddCodes/AddCodes.jsx
@@ -81,20 +81,22 @@ export default function AddCodes({ userId, releaseId, setOnCodeAdded }) {
 
         <div className="stack block-overflow">
           <label className="label" htmlFor="codes">
-            Codes
+            Enter manually
           </label>
           <textarea
             className="input block-resize"
             id="albumCodes"
-            placeholder="Enter your codes separated by a space"
+            placeholder="Copy and paste codes here"
             cols="20"
             rows="8"
-            onChange={(e) => setCodes(e.target.value)}
+            onChange={(e) => setCodes(e.target.value.split(/\s/g))}
           ></textarea>
 
           <label className="label" htmlFor="csvcodes">
-            Upload with CSV
+            Upload with Bandcamp CSV
           </label>
+          <br />
+          <small>Must be Bandcamp codes CSV or this will not work.</small>
           <input
             type="file"
             id="csvcodes"

--- a/components/AddCodes/AddCodes.jsx
+++ b/components/AddCodes/AddCodes.jsx
@@ -19,15 +19,12 @@ export default function AddCodes({ userId, releaseId, setOnCodeAdded }) {
       header: true,
       skipEmptyLines: true,
       complete: function (results) {
-        let codeString = ""
-        results.data.map((d, index) => {
+        let codeArray = results.data.map((d, index) => {
           if (index >= 8) {
-            let code = Object.values(d)
-
-            codeString = codeString + " " + code[0]
+            codeArray.push(Object.values(d)[0])
           }
         })
-        setCodes(codeString.trimStart().split(/\s/g))
+        setCodes(codeArray)
         toggleDisplayCodes(true)
       },
     })
@@ -85,7 +82,7 @@ export default function AddCodes({ userId, releaseId, setOnCodeAdded }) {
           </label>
           <textarea
             className="input block-resize"
-            id="albumCodes"
+            id="codes"
             placeholder="Copy and paste codes here"
             cols="20"
             rows="8"

--- a/components/Releases/CreateRelease.jsx
+++ b/components/Releases/CreateRelease.jsx
@@ -52,7 +52,7 @@ export default function CreateRelease() {
         artwork_url: artworkUrl,
         download_url: downloadUrl,
         type: type,
-        release_slug: slugify(title),
+        release_slug: slugify(title, { lower: true }),
         user_id: user.id,
       }
       const { data, error } = await supabase

--- a/components/Releases/ReleaseCard.jsx
+++ b/components/Releases/ReleaseCard.jsx
@@ -8,10 +8,19 @@ import IconRecord from "@/icons/vinyl-record.svg"
 import IconMusicNotes from "@/icons/music-notes.svg"
 import IconEdit from "@/icons/edit.svg"
 import UpdateRelease from "./UpdateRelease"
+import { useSupabaseClient } from "@supabase/auth-helpers-react"
 
 export default function ReleaseCard({ release, user, getReleases }) {
-  const [onCodeAdded, setOnCodeAdded] = useState(true)
+  const [onCodeAdded, setOnCodeAdded] = useState(false)
   const [showReleaseUpdateView, setShowReleaseUpdateView] = useState(false)
+  const supabase = useSupabaseClient()
+
+  useEffect(() => {
+    if (onCodeAdded) {
+      getReleases()
+      setOnCodeAdded(false)
+    }
+  }, [onCodeAdded])
 
   return (
     <li className={styles.component}>
@@ -64,7 +73,7 @@ export default function ReleaseCard({ release, user, getReleases }) {
             />
             <AddCodes
               userId={release.user_id}
-              releaseId={release.release_id}
+              releaseId={release.id}
               setOnCodeAdded={setOnCodeAdded}
             />
           </div>

--- a/components/Releases/ReleaseCard.module.css
+++ b/components/Releases/ReleaseCard.module.css
@@ -18,9 +18,6 @@
   padding: var(--padding);
 }
 
-.content {
-  display: grid;
-}
 
 .title {
   font-size: var(--step-2);

--- a/components/Releases/UpdateRelease.jsx
+++ b/components/Releases/UpdateRelease.jsx
@@ -84,7 +84,7 @@ export default function UpdateRelease({
           </label>
           <input
             className="input"
-            id="artowkrUrl"
+            id="artworkUrl"
             type="text"
             value={artworkUrl}
             onChange={(e) => setArtworkUrl(e.target.value)}

--- a/components/UpdateProfile/UpdateProfile.jsx
+++ b/components/UpdateProfile/UpdateProfile.jsx
@@ -17,10 +17,10 @@ export default function UpdateProfile({
     profileData.is_password_protected
   )
   const [pagePassword, setPagePassword] = useState(profileData.page_password)
-  const [sluggedName, setSluggedNamed] = useState(profileData.slug)
+  const [sluggedName, setSluggedName] = useState(profileData.slug)
 
   useEffect(() => {
-    setSluggedNamed(slugify(username, { lower: true }))
+    setSluggedName(slugify(username, { lower: true }))
   }, [username])
   async function updateUserProfile(avatarUrl) {
     try {

--- a/components/UpdateProfile/UpdateProfile.jsx
+++ b/components/UpdateProfile/UpdateProfile.jsx
@@ -1,7 +1,8 @@
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { useSupabaseClient } from "@supabase/auth-helpers-react"
 import Avatar from "../Avatar/Avatar"
 import AddImage from "../AddImage/AddImage"
+import slugify from "slugify"
 
 export default function UpdateProfile({
   getProfile,
@@ -9,16 +10,22 @@ export default function UpdateProfile({
   setShowUpdateView,
 }) {
   const supabase = useSupabaseClient()
+  const [username, setUsername] = useState(profileData.username)
   const [avatarUrl, setAvatarUrl] = useState(profileData.avatar_url)
   const [location, setLocation] = useState(profileData.location)
   const [isPasswordProtected, setIsPasswordProtected] = useState(
     profileData.is_password_protected
   )
   const [pagePassword, setPagePassword] = useState(profileData.page_password)
+  const [sluggedName, setSluggedNamed] = useState(profileData.slug)
 
+  useEffect(() => {
+    setSluggedNamed(slugify(username, { lower: true }))
+  }, [username])
   async function updateUserProfile(avatarUrl) {
     try {
       const updates = {
+        username: username,
         id: profileData.id,
         avatar_url: avatarUrl,
         updated_at: new Date().toISOString(),
@@ -41,7 +48,7 @@ export default function UpdateProfile({
 
   return (
     <div
-      classname="stack inline-max"
+      className="stack inline-max"
       style={{ "--max-inline-size": "var(--input-screen-inline-max-size" }}
     >
       <h1>Update profile</h1>
@@ -53,6 +60,23 @@ export default function UpdateProfile({
         setPublicUrl={(url) => setAvatarUrl(url)}
       />
       <br />
+
+      <label className="label" htmlFor="username">
+        Username
+      </label>
+      <br />
+      <small>
+        This will change your profile URL. https://downloadcodemanager.com/
+        {`${sluggedName}`}
+      </small>
+      <input
+        className="input"
+        id="username"
+        type="text"
+        value={username || ""}
+        onChange={(e) => setUsername(e.target.value)}
+        required
+      />
 
       <label className="label" htmlFor="location">
         Location
@@ -95,6 +119,7 @@ export default function UpdateProfile({
           className="button"
           data-variant="primary"
           onClick={() => updateUserProfile(avatarUrl)}
+          disabled={!username}
         >
           Update
         </button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "eslint-config-next": "13.2.3",
         "next": "13.2.3",
         "open-props": "^1.5.6",
+        "papaparse": "^5.4.1",
         "postcss-jit-props": "^1.0.12",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -5670,6 +5671,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/papaparse": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
+      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "eslint-config-next": "13.2.3",
     "next": "13.2.3",
     "open-props": "^1.5.6",
+    "papaparse": "^5.4.1",
     "postcss-jit-props": "^1.0.12",
     "react": "18.2.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
This PR request implements logic in AddCodes making it possible to upload a CSV file and parse the codes from it.

The user can click on add codes, and then upload their CSV file from bandcamp. The app then parses the codes, and displays them for the user to check. As of now, they can not remove codes, or add additional, until the codes are uploaded. 

This takes away the chance of human error when copying and pasting codes, or entering the codes manually.

We still need to come up with how to make sure codes arent entered multiple times, and what happens if somebody uploads a CSV that is not formatted correctly.

Also added the ability to change your username in update profile. Added text above the input warning that this will change their profile URL, and also added what their URL will be if they change.

fixed a spelling error in update release