### PR TITLE
Refactored sign up page and added delete release

### DIFF
--- a/components/Releases/UpdateRelease.jsx
+++ b/components/Releases/UpdateRelease.jsx
@@ -56,6 +56,38 @@ export default function UpdateRelease({
     }
   }
 
+  async function deleteRelease() {
+    const deleteCheck = window.prompt(
+      `Please enter '${release.title}' to delete this release.`
+    )
+
+    if (deleteCheck === release.title) {
+      try {
+        let { error: codeError } = await supabase
+          .from("codes")
+          .delete()
+          .eq("release_id", release.id)
+
+        let { error: releaseError } = await supabase
+          .from("releases")
+          .delete()
+          .eq("id", release.id)
+
+        if (codeError) throw error
+        if (releaseError) throw error
+        alert("Release deleted.")
+      } catch (error) {
+        alert("Error deleting data!")
+        console.log(error)
+      } finally {
+        getReleases()
+        setShowReleaseUpdateView(false)
+      }
+    } else {
+      alert("Incorrect input")
+    }
+  }
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger
@@ -142,6 +174,14 @@ export default function UpdateRelease({
             }
           >
             Update
+          </button>
+
+          <button
+            className="button"
+            data-variant="secondary"
+            onClick={deleteRelease}
+          >
+            Delete
           </button>
           <DialogClose className="button">Cancel</DialogClose>
         </footer>

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -1,6 +1,8 @@
 import { supabase } from "@/utils/supabase"
 import { useState } from "react"
 import Link from "next/link"
+import slugify from "slugify"
+import { useRouter } from "next/router"
 
 const accountTypes = [
   { id: 1, text: "Label" },
@@ -15,17 +17,15 @@ const Signup = () => {
     passwordCheck: "",
     type: accountTypes[2].text,
     name: "",
-    avatar: "",
     location: "",
   })
   const [userCreated, setUserCreated] = useState(false)
-
+  const router = useRouter()
   const handleChange = (e) => {
     setNewUser({ ...newUser, [e.target.id]: e.target.value })
   }
 
   const handleSubmit = async (e) => {
-    let slugger = newUser.name.toLowerCase()
     e.preventDefault()
     let { data, error } = await supabase.auth.signUp({
       email: newUser.email,
@@ -34,12 +34,8 @@ const Signup = () => {
         data: {
           type: newUser.type,
           username: newUser.name,
-          avatar_url: newUser.avatar,
           location: newUser.location,
-          slug: slugger
-            .replace(/[^a-z0-9 -]/g, "")
-            .replace(/\s+/g, "-")
-            .replace(/-+/g, "-"),
+          slug: slugify(newUser.name, { lower: true }),
         },
       },
     })
@@ -61,23 +57,26 @@ const Signup = () => {
     }
   }
   return (
-    <div className="signup form-container">
+    <article
+      className="container stack inline-max center-stage"
+      style={{ "--max-inline-size": "400px" }}
+    >
       {userCreated ? (
         <div className="user-created">
           <h1>New User Created</h1>
           <p>
-            Thank you for signing up! Please sign in to continue creating your
-            profile.
+            Thank you for signing up! Please sign in to access your dashboard.
           </p>
           <Link href="/">Sign In</Link>
         </div>
       ) : (
-        <div className="create-user">
+        <div>
           <h1>Create User</h1>
-          <form className="create-user-form" onSubmit={handleSubmit}>
+          <form className="stack" onSubmit={handleSubmit}>
             <div className="input-wrapper">
               <label htmlFor="email">Email</label>
               <input
+                className="input"
                 onChange={handleChange}
                 id="email"
                 type="email"
@@ -85,20 +84,23 @@ const Signup = () => {
                 required
               />
             </div>
+
             <div className="input-wrapper">
               <label htmlFor="password">Password</label>
               <input
+                className="input"
                 onChange={handleChange}
                 id="password"
                 type="password"
                 value={newUser.password}
                 required
               />
-              <p>Password must be at least six characters long</p>
+              <small>Password must be at least six characters long</small>
             </div>
             <div className="input-wrapper">
               <label htmlFor="passwordCheck">Re-enter password</label>
               <input
+                className="input"
                 onChange={handleChange}
                 id="passwordCheck"
                 type="password"
@@ -109,6 +111,7 @@ const Signup = () => {
             <div className="input-wrapper">
               <label htmlFor="type">Account type</label>
               <select
+                className="input"
                 onChange={handleChange}
                 id="type"
                 value={newUser.type}
@@ -131,6 +134,7 @@ const Signup = () => {
                 <div className="input-wrapper">
                   <label htmlFor="name">Label Name</label>
                   <input
+                    className="input"
                     onChange={handleChange}
                     id="name"
                     type="text"
@@ -138,18 +142,11 @@ const Signup = () => {
                     required
                   />
                 </div>
-                <div className="input-wrapper">
-                  <label htmlFor="name">Label avatar</label>
-                  <input
-                    onChange={handleChange}
-                    id="avatar"
-                    type="text"
-                    value={newUser.avatar_url}
-                  />
-                </div>
+
                 <div className="input-wrapper">
                   <label htmlFor="location">Label location</label>
                   <input
+                    className="input"
                     onChange={handleChange}
                     id="location"
                     type="text"
@@ -162,6 +159,7 @@ const Signup = () => {
                 <div className="input-wrapper">
                   <label htmlFor="name">Artist Name</label>
                   <input
+                    className="input"
                     onChange={handleChange}
                     id="name"
                     type="text"
@@ -169,18 +167,11 @@ const Signup = () => {
                     required
                   />
                 </div>
-                <div className="input-wrapper">
-                  <label htmlFor="name">Artist avatar</label>
-                  <input
-                    onChange={handleChange}
-                    id="avatar"
-                    type="text"
-                    value={newUser.avatar_url}
-                  />
-                </div>
+
                 <div className="input-wrapper">
                   <label htmlFor="location">Artist location</label>
                   <input
+                    className="input"
                     onChange={handleChange}
                     id="location"
                     type="text"
@@ -191,7 +182,8 @@ const Signup = () => {
             )}
             <button
               type="submit"
-              className="btn primary"
+              className="button"
+              data-variant="primary"
               disabled={
                 !newUser.email ||
                 !newUser.password ||
@@ -203,10 +195,18 @@ const Signup = () => {
             >
               Sign Up
             </button>
+            <button
+              type="button"
+              className="button"
+              data-variant="secondary"
+              onClick={() => router.push("/")}
+            >
+              Cancel
+            </button>
           </form>
         </div>
       )}
-    </div>
+    </article>
   )
 }
 


### PR DESCRIPTION
This PR is an update to the current signup page as well as the ability to delete a release.

Styles have been added to make it look more like the login page.

artist/label avatar has been removed, as it is impossible to upload an image before a user is created. We can direct the user to upload their avatar on first login.

Delete release has been added to the update release view. The user will be prompted to enter the release name exactly in order for the release to be deleted. This also deletes all codes associated with the release.