### PR TITLE
Add releases empty state and create action card

### DIFF
--- a/components/Layout/Layout.jsx
+++ b/components/Layout/Layout.jsx
@@ -29,7 +29,11 @@ export default function Layout({ children }) {
         ) : null}
       </header>
       <main className="inline-max stack">{children}</main>
-      <footer></footer>
+      <footer className={styles.footer}>
+        <p>
+          Footer content: copyright info, contact links, privacy policy, etc.
+        </p>
+      </footer>
     </>
   )
 }

--- a/components/Layout/Layout.module.css
+++ b/components/Layout/Layout.module.css
@@ -3,7 +3,12 @@
   justify-content: space-between;
   gap: var(--size-2);
   padding: var(--size-2) var(--size-4);
-  border-bottom: var(--border-size-1) solid var(--surface-4);
+  border-block-start: var(--border-size-1) solid var(--surface-3);
+}
+
+.footer {
+  padding: var(--size-6) var(--size-4);
+  text-align: center;
 }
 
 .title {

--- a/components/Releases/CreateRelease.jsx
+++ b/components/Releases/CreateRelease.jsx
@@ -19,7 +19,7 @@ const releaseTypes = [
   { id: 6, text: "Choose release type", isDisabled: true },
 ]
 
-export default function CreateRelease({ open, onOpenChange }) {
+export default function CreateRelease({ open, onOpenChange, trigger }) {
   const user = useUser()
   const supabase = useSupabaseClient()
   const [title, setTitle] = useState()
@@ -69,10 +69,15 @@ export default function CreateRelease({ open, onOpenChange }) {
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogTrigger className="button" data-variant="primary">
-        <IconMusicNotesPlus aria-hidden="true" /> Create new release
-      </DialogTrigger>
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      onCloseAutoFocus={(e) => {
+        console.log("hi")
+        e.preventDefault()
+      }}
+    >
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
 
       <DialogContent>
         <header>

--- a/components/Releases/CreateRelease.jsx
+++ b/components/Releases/CreateRelease.jsx
@@ -19,10 +19,9 @@ const releaseTypes = [
   { id: 6, text: "Choose release type", isDisabled: true },
 ]
 
-export default function CreateRelease() {
+export default function CreateRelease({ open, onOpenChange }) {
   const user = useUser()
   const supabase = useSupabaseClient()
-  const [open, setOpen] = useState(false)
   const [title, setTitle] = useState()
   const [artist, setArtist] = useState(
     user.user_metadata.type === "Artist" ? user.user_metadata.name : ""
@@ -65,12 +64,12 @@ export default function CreateRelease() {
     } finally {
       console.log("All done!")
 
-      setOpen(false)
+      onOpenChange(false)
     }
   }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogTrigger className="button" data-variant="primary">
         <IconMusicNotesPlus aria-hidden="true" /> Create new release
       </DialogTrigger>

--- a/components/Releases/CreateRelease.jsx
+++ b/components/Releases/CreateRelease.jsx
@@ -22,6 +22,7 @@ const releaseTypes = [
 export default function CreateRelease({ trigger }) {
   const user = useUser()
   const supabase = useSupabaseClient()
+  const [open, setOpen] = useState(false)
   const [title, setTitle] = useState()
   const [artist, setArtist] = useState(
     user.user_metadata.type === "Artist" ? user.user_metadata.name : ""
@@ -63,20 +64,12 @@ export default function CreateRelease({ trigger }) {
       alert("Error creating new release!")
     } finally {
       console.log("All done!")
-
-      onOpenChange(false)
+      setOpen(false)
     }
   }
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={onOpenChange}
-      onCloseAutoFocus={(e) => {
-        console.log("hi")
-        e.preventDefault()
-      }}
-    >
+    <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
 
       <DialogContent>

--- a/components/Releases/CreateRelease.jsx
+++ b/components/Releases/CreateRelease.jsx
@@ -19,7 +19,7 @@ const releaseTypes = [
   { id: 6, text: "Choose release type", isDisabled: true },
 ]
 
-export default function CreateRelease({ open, onOpenChange, trigger }) {
+export default function CreateRelease({ trigger }) {
   const user = useUser()
   const supabase = useSupabaseClient()
   const [title, setTitle] = useState()

--- a/components/Releases/ReleaseCard.module.css
+++ b/components/Releases/ReleaseCard.module.css
@@ -34,8 +34,9 @@
 .image {
   flex-shrink: 0;
   width: 100%;
+  height: 100%;
+  object-fit: cover;
   max-inline-size: 100px;
-  height: auto;
   aspect-ratio: 1;
   border-radius: var(--radius-1);
 }

--- a/components/Releases/ReleaseCard.module.css
+++ b/components/Releases/ReleaseCard.module.css
@@ -18,7 +18,6 @@
   padding: var(--padding);
 }
 
-
 .title {
   font-size: var(--step-2);
 }

--- a/components/Releases/Releases.jsx
+++ b/components/Releases/Releases.jsx
@@ -2,11 +2,19 @@ import { useState, useEffect } from "react"
 import { useUser, useSupabaseClient } from "@supabase/auth-helpers-react"
 import ReleaseCard from "./ReleaseCard"
 import CreateRelease from "./CreateRelease"
+import styles from "./Releases.module.css"
+import cn from "classnames"
+import IconMusicNotesPlus from "@/icons/music-notes-plus.svg"
 
 export default function Releases() {
   const supabase = useSupabaseClient()
   const user = useUser()
   const [releases, setReleases] = useState([])
+  const [openCreateRelease, setOpenCreateRelease] = useState(false)
+
+  useEffect(() => {
+    console.log(openCreateRelease)
+  }, [openCreateRelease])
 
   useEffect(() => {
     getReleases()
@@ -57,17 +65,41 @@ export default function Releases() {
       <header className="article-heading inline-wrap">
         <h2>Releases</h2>
 
-        <CreateRelease />
+        <CreateRelease
+          open={openCreateRelease}
+          onOpenChange={setOpenCreateRelease}
+        />
       </header>
       <ul className="grid" role="list">
-        {releases.map((release) => (
-          <ReleaseCard
-            key={release.id}
-            release={release}
-            user={user}
-            getReleases={getReleases}
-          />
-        ))}
+        {releases.length ? (
+          <>
+            {releases.map((release) => (
+              <ReleaseCard
+                key={release.id}
+                release={release}
+                user={user}
+                getReleases={getReleases}
+              />
+            ))}
+            <li
+              className={cn(styles.actionCard, "container")}
+              data-variant="empty"
+            >
+              <button
+                className={cn(styles.actionCardButton, "button")}
+                data-variant="text"
+                onClick={() => setOpenCreateRelease(true)}
+              >
+                <IconMusicNotesPlus aria-hidden="true" />
+                Create a new release
+              </button>
+            </li>
+          </>
+        ) : (
+          <div className={cn(styles.empty, "container")} data-variant="empty">
+            <p>Your releases list is currently empty.</p>
+          </div>
+        )}
       </ul>
     </article>
   )

--- a/components/Releases/Releases.jsx
+++ b/components/Releases/Releases.jsx
@@ -10,7 +10,6 @@ export default function Releases() {
   const supabase = useSupabaseClient()
   const user = useUser()
   const [releases, setReleases] = useState([])
-  const [openCreateRelease, setOpenCreateRelease] = useState(false)
 
   useEffect(() => {
     getReleases()
@@ -60,12 +59,15 @@ export default function Releases() {
     <article className="stack">
       <header className="article-heading inline-wrap">
         <h2>Releases</h2>
-
         <CreateRelease
-          open={openCreateRelease}
-          onOpenChange={setOpenCreateRelease}
+          trigger={
+            <button className="button" data-variant="primary">
+              <IconMusicNotesPlus aria-hidden="true" /> Create new release
+            </button>
+          }
         />
       </header>
+
       <ul className="grid" role="list">
         {releases.length ? (
           <>
@@ -81,14 +83,17 @@ export default function Releases() {
               className={cn(styles.actionCard, "container")}
               data-variant="empty"
             >
-              <button
-                className={cn(styles.actionCardButton, "button")}
-                data-variant="text"
-                onClick={() => setOpenCreateRelease(true)}
-              >
-                <IconMusicNotesPlus aria-hidden="true" />
-                Create a new release
-              </button>
+              <CreateRelease
+                trigger={
+                  <button
+                    className={cn(styles.actionCardButton, "button")}
+                    data-variant="text"
+                  >
+                    <IconMusicNotesPlus aria-hidden="true" />
+                    Create a new release
+                  </button>
+                }
+              />
             </li>
           </>
         ) : (

--- a/components/Releases/Releases.jsx
+++ b/components/Releases/Releases.jsx
@@ -13,10 +13,6 @@ export default function Releases() {
   const [openCreateRelease, setOpenCreateRelease] = useState(false)
 
   useEffect(() => {
-    console.log(openCreateRelease)
-  }, [openCreateRelease])
-
-  useEffect(() => {
     getReleases()
   }, [supabase, user.id])
   async function getReleases() {

--- a/components/Releases/Releases.module.css
+++ b/components/Releases/Releases.module.css
@@ -1,0 +1,21 @@
+.empty {
+  grid-column: 1 / -1;
+  padding: var(--size-6);
+}
+
+.actionCard {
+  display: grid;
+  place-content: center;
+  place-items: center;
+  transition: border-color 200ms ease-out;
+}
+
+.actionCardButton {
+  --button-icon-size: 2em;
+  gap: var(--size-1);
+  flex-direction: column;
+}
+
+.actionCard:has(button:hover) {
+  border-color: var(--link-hover);
+}

--- a/styles/blocks.css
+++ b/styles/blocks.css
@@ -8,3 +8,31 @@
   padding: 2px var(--size-3);
   border-radius: var(--radius-1);
 }
+
+.container {
+  padding: var(--size-3);
+  border-radius: var(--radius-conditional-2);
+  border: var(--border-size-1) solid var(--surface-3);
+  background-color: var(--surface-2);
+  box-shadow: var(--shadow-3);
+}
+
+.container[data-variant="empty"] {
+  text-align: center;
+  border-style: dashed;
+  background-color: transparent;
+  box-shadow: unset;
+}
+
+.input-screen {
+  display: grid;
+  place-items: center;
+  min-height: 80vh;
+  padding-block: var(--size-8);
+}
+
+.article-heading {
+  --inline-wrap-gap: var(--size-2);
+  justify-content: space-between;
+  align-items: baseline;
+}

--- a/styles/composition.css
+++ b/styles/composition.css
@@ -1,5 +1,6 @@
 .grid {
   display: grid;
+  grid-auto-rows: 1fr;
   grid-template-columns: repeat(
     auto-fill,
     minmax(min(var(--grid-min-inline-size, 400px), 100%), 1fr)
@@ -30,25 +31,4 @@
   flex-basis: 100%;
   gap: var(--inline-wrap-gap, var(--size-4));
   align-items: flex-start;
-}
-
-.container {
-  padding: var(--size-3);
-  border-radius: var(--radius-conditional-2);
-  border: var(--border-size-1) solid var(--surface-3);
-  background-color: var(--surface-2);
-  box-shadow: var(--shadow-3);
-}
-
-.input-screen {
-  display: grid;
-  place-items: center;
-  min-height: 80vh;
-  padding-block: var(--size-8);
-}
-
-.article-heading {
-  --inline-wrap-gap: var(--size-2);
-  justify-content: space-between;
-  align-items: baseline;
 }

--- a/styles/forms.css
+++ b/styles/forms.css
@@ -31,6 +31,9 @@
 
 .button {
   display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
   position: relative;
   cursor: pointer;
   border-width: 1px;
@@ -84,17 +87,28 @@
 
 .button[data-variant="secondary"] {
   --button-bg-color: var(--brand-2);
-  --button-border-color: var(--brand-2);
+  --button-border-color: var(--button-bg-color);
   --button-text-color: var(--brand-2-text);
 }
 
 .button[data-variant="secondary"]:hover {
   --button-bg-color: var(--brand-2-hover);
-  --button-border-color: var(--brand-2-hover);
+  --button-border-color: var(--button-bg-color);
 }
 
 .button[data-variant="dashed"] {
   border-style: dashed;
+}
+
+.button[data-variant="text"] {
+  --button-bg-color: transparent;
+  --button-border-color: transparent;
+  --button-text-color: var(--link);
+  box-shadow: unset;
+}
+
+.button[data-variant="text"]:hover {
+  --button-text-color: var(--link-hover);
 }
 
 .button-actions {

--- a/styles/forms.css
+++ b/styles/forms.css
@@ -33,6 +33,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: var(--size-1);
   text-align: center;
   position: relative;
   cursor: pointer;
@@ -45,12 +46,9 @@
 
 .button svg {
   flex-shrink: 0;
-  position: relative;
-  top: 0.1em;
   inline-size: var(--button-icon-size, 1.25em);
   block-size: var(--button-icon-size, 1.25em);
   margin-inline-start: calc(var(--size-1) * -1);
-  margin-inline-end: var(--size-2);
 }
 
 .button:not(:disabled) {

--- a/styles/forms.css
+++ b/styles/forms.css
@@ -1,5 +1,5 @@
 .label {
-  display: inline-block;
+  display: block;
 }
 
 .input {

--- a/styles/variables.css
+++ b/styles/variables.css
@@ -1,7 +1,6 @@
 :where(html) {
   color-scheme: light dark;
 
-
   --brand-1: var(--blue-6);
   --brand-1-hover: var(--blue-7);
   --brand-1-text: var(--gray-0);
@@ -14,12 +13,13 @@
   --text-inverse-1: var(--gray-1);
   --text-inverse-2: var(--gray-2);
   --text-hover-1: var(--gray-12);
-
+  --link: var(--blue-8);
+  --link-hover: var(--blue-7);
 
   --surface-1: var(--gray-0);
   --surface-2: var(--gray-1);
-  --surface-3: var(--gray-3);
-  --surface-4: var(--gray-4);
+  --surface-3: var(--gray-4);
+  --surface-4: var(--gray-5);
 
   --surface-success-1: var(--green-1);
   --surface-success-2: var(--green-2);
@@ -31,10 +31,8 @@
   --input-icon-color: var(--gray-5);
   --input-screen-max-inline-size: 450px;
 
-
   --page-max-inline-size: 1000px;
   --page-padding: clamp(var(--size-2), 8vw, var(--size-3));
-
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
* If there are no releases, this shows an initial empty state.
* Adds a "Create a new release" action card in the releases list. Handy if a user has a bunch of releases like our test account does now.
  * ~_Tiny accessibility issue here_: While the dialog can be opened this way, when it closes, focus currently goes back to the dialog's trigger instead of the action card that opened it. Definitely needs to be explored a bit more. It might be possible that I can use `onCloseAutoFocus` [[docs](https://www.radix-ui.com/docs/primitives/components/dialog)] to set the focus where desired programmatically. If this experience ultimately feels clunky, I'm thinking that this component just gets tossed in the bin.~ This is no longer an issue now that the `trigger` is passed as a prop.
* Adds some test footer copy so we can remember to add info to the footer (if necessary)

<img width="800" alt="Screenshot 2023-04-01 at 9 01 48 AM" src="https://user-images.githubusercontent.com/1704038/229301497-d02849f9-e007-4d11-8aa6-a8360b99b7c4.png">
<img width="800" alt="Screenshot 2023-04-01 at 9 00 24 AM" src="https://user-images.githubusercontent.com/1704038/229301494-ea7563c6-6e02-4b95-ae22-862af506b01d.png">
