### PR TITLE
Feat/sub bulk delete

### DIFF
--- a/components/Account/Account.jsx
+++ b/components/Account/Account.jsx
@@ -64,7 +64,7 @@ export default function Account({ session }) {
           </div>
           <div className={styles.url}>
             <strong>Profile page: </strong>
-            <a href={`/${user.user_metadata.type}s/${user.user_metadata.slug}`}>
+            <a href={`/${user.user_metadata.slug}`}>
               {user.user_metadata.slug}
             </a>
           </div>

--- a/components/AddImage/AddImage.jsx
+++ b/components/AddImage/AddImage.jsx
@@ -24,16 +24,6 @@ export default function AddImage({ uid, setPublicUrl, setNewImagePath }) {
         throw new Error("You must select an image to upload.")
       }
 
-      // if (imagePath) {
-      //   let { data, error } = await supabase.storage
-      //     .from("images")
-      //     .remove([imagePath])
-
-      //   if (error) {
-      //     alert(error)
-      //   }
-      // }
-
       const file = event.target.files[0]
 
       let { data, error: uploadError } = await supabase.storage

--- a/components/AddImage/AddImage.jsx
+++ b/components/AddImage/AddImage.jsx
@@ -4,12 +4,7 @@ import IconUpload from "@/icons/upload.svg"
 import cn from "classnames"
 import { v4 as uuidv4 } from "uuid"
 
-export default function AddImage({
-  uid,
-  setPublicUrl,
-  imagePath,
-  setImagePath,
-}) {
+export default function AddImage({ uid, setPublicUrl, setNewImagePath }) {
   const supabase = useSupabaseClient()
   const [uploading, setUploading] = useState(false)
 
@@ -29,15 +24,15 @@ export default function AddImage({
         throw new Error("You must select an image to upload.")
       }
 
-      if (imagePath) {
-        let { data, error } = await supabase.storage
-          .from("images")
-          .remove([imagePath])
+      // if (imagePath) {
+      //   let { data, error } = await supabase.storage
+      //     .from("images")
+      //     .remove([imagePath])
 
-        if (error) {
-          alert(error)
-        }
-      }
+      //   if (error) {
+      //     alert(error)
+      //   }
+      // }
 
       const file = event.target.files[0]
 
@@ -50,7 +45,7 @@ export default function AddImage({
       }
 
       if (data) {
-        setImagePath(data.path)
+        setNewImagePath(data.path)
         getPublicUrl(data)
       } else {
         console.log(error)

--- a/components/Profile/Profile.jsx
+++ b/components/Profile/Profile.jsx
@@ -7,7 +7,7 @@ export default function ProfileLayout({
   name,
   location,
   releases,
-  slug,
+  profileSlug,
 }) {
   return (
     <div className="label-wrapper">
@@ -17,7 +17,11 @@ export default function ProfileLayout({
       <ul className="stack" role="list">
         {releases.map((release) =>
           release.is_active ? (
-            <ReleaseCard key={release.id} release={release} />
+            <ReleaseCard
+              key={release.id}
+              release={release}
+              profileSlug={profileSlug}
+            />
           ) : null
         )}
       </ul>

--- a/components/Profile/Profile.jsx
+++ b/components/Profile/Profile.jsx
@@ -16,7 +16,7 @@ export default function ProfileLayout({
       <h2>{location}</h2>
       <ul className="stack" role="list">
         {releases.map((release) =>
-          release.codes.length > 0 && release.is_active ? (
+          release.is_active ? (
             <ReleaseCard key={release.id} release={release} />
           ) : null
         )}

--- a/components/Releases/CreateRelease.jsx
+++ b/components/Releases/CreateRelease.jsx
@@ -39,7 +39,7 @@ export default function CreateRelease({
   const [pagePassword, setPagePassword] = useState()
   const [isPasswordProtected, setIsPasswordProtected] = useState(false)
   const [type, setType] = useState(releaseTypes[5].text)
-  const [imagePath, setImagePath] = useState()
+  const [newImagePath, setNewImagePath] = useState()
 
   async function createNewRelease({
     title,
@@ -55,7 +55,7 @@ export default function CreateRelease({
         artist: artist,
         label: label,
         artwork_url: artworkUrl,
-        artwork_path: imagePath,
+        artwork_path: newImagePath,
         yum_url: yumUrl,
         type: type,
         release_slug: slugify(title, { lower: true }),
@@ -72,6 +72,20 @@ export default function CreateRelease({
       console.log("All done!")
       setAddedNewRelease(true)
       setOpen(false)
+    }
+  }
+
+  async function cancelCreate() {
+    if (newImagePath) {
+      try {
+        let { error } = await supabase.storage
+          .from("images")
+          .remove([newImagePath])
+        if (error) alert(error)
+        setOpen(false)
+      } catch (error) {
+        throw error
+      }
     }
   }
 
@@ -123,8 +137,7 @@ export default function CreateRelease({
             setPublicUrl={(url) => {
               setArtworkUrl(url)
             }}
-            setImagePath={setImagePath}
-            imagePath={imagePath}
+            setNewImagePath={setNewImagePath}
           />
 
           <label className="label" htmlFor="artworkUrl">
@@ -189,7 +202,9 @@ export default function CreateRelease({
           >
             Create
           </button>
-          <DialogClose className="button">Cancel</DialogClose>
+          <button className="button" onClick={() => cancelCreate()}>
+            Cancel
+          </button>
         </footer>
       </DialogContent>
     </Dialog>

--- a/components/Releases/ReleaseCard.jsx
+++ b/components/Releases/ReleaseCard.jsx
@@ -15,6 +15,7 @@ export default function ReleaseCard({
   user,
   getReleases,
   profileData,
+  profileSlug,
 }) {
   const [onCodeAdded, setOnCodeAdded] = useState(false)
   const [showReleaseUpdateView, setShowReleaseUpdateView] = useState(false)
@@ -46,7 +47,7 @@ export default function ReleaseCard({
         <div className={styles.details}>
           <div>
             <h3 className={styles.title}>
-              <Link href={`/releases/${release.release_slug}`}>
+              <Link href={`/${profileSlug}/${release.release_slug}`}>
                 {release.title}
               </Link>
             </h3>

--- a/components/Releases/Releases.jsx
+++ b/components/Releases/Releases.jsx
@@ -82,6 +82,7 @@ export default function Releases({ profileData }) {
                   user={user}
                   getReleases={getReleases}
                   profileData={profileData}
+                  profileSlug={user.user_metadata.slug}
                 />
               ) : null
             )}

--- a/components/UpdateProfile/UpdateProfile.jsx
+++ b/components/UpdateProfile/UpdateProfile.jsx
@@ -40,6 +40,7 @@ export default function UpdateProfile({
         id: profileData.id,
         avatar_url: avatarUrl,
         avatar_path: newImagePath ? newImagePath : imagePath,
+        sites: socialLinks,
         yum_url: yumUrl,
         updated_at: new Date().toISOString(),
       }
@@ -77,11 +78,11 @@ export default function UpdateProfile({
           .from("images")
           .remove([newImagePath])
         if (error) alert(error)
-        setOpen(false)
       } catch (error) {
         throw error
       }
     }
+    setOpen(false)
   }
 
   return (
@@ -111,7 +112,7 @@ export default function UpdateProfile({
           <small>
             This will change your profile URL.{" "}
             {process.env.NEXT_PUBLIC_DLCM_URL}
-            {profileData.type}/{`${sluggedName}`}
+            {`${sluggedName}`}
           </small>
           <input
             className="input"

--- a/components/UpdateProfile/UpdateProfile.jsx
+++ b/components/UpdateProfile/UpdateProfile.jsx
@@ -26,20 +26,33 @@ export default function UpdateProfile({
   const [pagePassword, setPagePassword] = useState(profileData.page_password)
   const [sluggedName, setSluggedName] = useState(profileData.slug)
   const [imagePath, setImagePath] = useState(profileData.avatar_path)
+  const [newImagePath, setNewImagePath] = useState()
   const [yumUrl, setYumUrl] = useState(profileData.yum_url)
 
   useEffect(() => {
     setSluggedName(slugify(username, { lower: true }))
   }, [username])
+
   async function updateUserProfile() {
     try {
       const updates = {
         username: username,
         id: profileData.id,
         avatar_url: avatarUrl,
-        avatar_path: imagePath,
+        avatar_path: newImagePath ? newImagePath : imagePath,
         yum_url: yumUrl,
         updated_at: new Date().toISOString(),
+      }
+
+      if (newImagePath) {
+        try {
+          let { error } = await supabase.storage
+            .from("images")
+            .remove([imagePath])
+          if (error) alert(error)
+        } catch (error) {
+          throw error
+        }
       }
 
       let { error } = await supabase
@@ -54,6 +67,20 @@ export default function UpdateProfile({
     } finally {
       getProfile()
       setShowUpdateView(false)
+    }
+  }
+
+  async function cancelUpdate() {
+    if (newImagePath) {
+      try {
+        let { error } = await supabase.storage
+          .from("images")
+          .remove([newImagePath])
+        if (error) alert(error)
+        setOpen(false)
+      } catch (error) {
+        throw error
+      }
     }
   }
 
@@ -73,8 +100,7 @@ export default function UpdateProfile({
           <AddImage
             uid={profileData.id}
             setPublicUrl={(url) => setAvatarUrl(url)}
-            setImagePath={setImagePath}
-            imagePath={imagePath}
+            setNewImagePath={setNewImagePath}
           />
           <br />
 
@@ -150,14 +176,18 @@ export default function UpdateProfile({
           <button
             className="button"
             data-variant="primary"
-            onClick={() => updateUserProfile(avatarUrl)}
+            onClick={() => updateUserProfile()}
             disabled={!username}
           >
             Update
           </button>
-          <DialogClose className="button">Cancel</DialogClose>
+          <button className="button" onClick={() => cancelUpdate()}>
+            Cancel
+          </button>
         </footer>
       </DialogContent>
     </Dialog>
   )
 }
+
+// <DialogClose className="button">Cancel</DialogClose>

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -1,0 +1,37 @@
+import { supabase } from "@/utils/supabase"
+import ProfileLayout from "@/components/Profile/Profile"
+import ReleaseLayout from "@/components/Releases/ReleaseLayout"
+
+export async function getServerSideProps({ params }) {
+  let { data: profile, error } = await supabase
+    .from("profiles")
+    .select("*, releases(*, codes(*))")
+    .eq("slug", params.slug)
+    .single()
+
+  return { props: { profile, params } }
+}
+
+export default function ProfilePage({ profile, params }) {
+  if (params.length == 1) {
+    return profile ? (
+      <ProfileLayout
+        avatar={profile.avatar_url}
+        name={profile.name}
+        location={profile.location}
+        releases={profile.releases}
+        slug={profile.slug}
+      />
+    ) : (
+      <div>Loading...</div>
+    )
+  }
+
+  if (params.length == 2) {
+    return profile.releases ? (
+      <ReleaseLayout release={release} />
+    ) : (
+      <div>Loading...</div>
+    )
+  }
+}

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -6,32 +6,36 @@ export async function getServerSideProps({ params }) {
   let { data: profile, error } = await supabase
     .from("profiles")
     .select("*, releases(*, codes(*))")
-    .eq("slug", params.slug)
+    .eq("slug", params.slug[0])
     .single()
 
   return { props: { profile, params } }
 }
 
 export default function ProfilePage({ profile, params }) {
-  if (params.length == 1) {
+  if (params.slug.length == 1) {
     return profile ? (
       <ProfileLayout
         avatar={profile.avatar_url}
         name={profile.name}
         location={profile.location}
         releases={profile.releases}
-        slug={profile.slug}
+        profileSlug={profile.slug}
       />
     ) : (
       <div>Loading...</div>
     )
   }
 
-  if (params.length == 2) {
-    return profile.releases ? (
-      <ReleaseLayout release={release} />
+  if (params.slug.length == 2) {
+    return profile ? (
+      profile.releases.map((release, index) =>
+        release.release_slug == params.slug[1] ? (
+          <ReleaseLayout key={index} release={release} />
+        ) : null
+      )
     ) : (
-      <div>Loading...</div>
+      <div>No Release Found</div>
     )
   }
 }

--- a/pages/api/stripe-webhooks.js
+++ b/pages/api/stripe-webhooks.js
@@ -50,13 +50,16 @@ export default async function handler(req, res) {
       .order("created_at", { ascending: false })
 
     let releasesToDelete = []
+    let imagesToDelete = []
     userReleases.map((release, index) => {
       if (index > 1) {
         releasesToDelete.push(release.id)
+        imagesToDelete.push(release.artwork_path)
       }
     })
 
     await supabase.from("releases").delete().in("id", releasesToDelete)
+    await supabase.storage.from("images").remove(imagesToDelete)
   }
 
   if (event.type == "customer.subscription.created") {
@@ -67,7 +70,7 @@ export default async function handler(req, res) {
 
   if (event.type == "customer.subscription.deleted") {
     const customerSubscriptionDeleted = event.data.object
-    canceledSub(subscriptionScheduleCanceled.customer)
+    canceledSub(customerSubscriptionDeleted.customer)
     // Then define and call a function to handle the event customer.subscription.deleted
   }
 

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -21,6 +21,7 @@ const Signup = () => {
   })
   const [userCreated, setUserCreated] = useState(false)
   const router = useRouter()
+
   const handleChange = (e) => {
     setNewUser({ ...newUser, [e.target.id]: e.target.value })
   }


### PR DESCRIPTION
This feature branch dealt with two concerns.

AddImage has been refactored. Still an issue if a user adds and image, and then clicks on add image again. Will cause an image to be added to database that should be deleted. Also implemented bulk delete on subscription cancelation.

Refactored routing to remove /account-type/user-name and /account-type/user-name/releases/release-name 
