### PR TITLE
ability to create custom slugs

### DIFF
--- a/components/Layout/Layout.jsx
+++ b/components/Layout/Layout.jsx
@@ -33,14 +33,13 @@ export default function Layout({ children }) {
       </header>
       <main className="inline-max stack">{children}</main>
       <footer className={styles.footer}>
-        <div className={styles.terms}>
+        <div className={styles.copyright}>
           <p>&copy; {`${date.getFullYear()}`} Mystery Circles</p>
-
-          <Link href="/terms">Terms and Conditions</Link>
         </div>
         <div className={styles.contact}>
           <a href="mailto:dlcm.app@gmail.com">Contact Us</a>
           <Link href="/privacy">Privacy Policy</Link>
+          <Link href="/terms">Terms and Conditions</Link>
         </div>
       </footer>
     </>

--- a/components/Layout/Layout.module.css
+++ b/components/Layout/Layout.module.css
@@ -8,6 +8,7 @@
 
 .footer {
   display: flex;
+  /* flex-direction: column; */
   justify-content: center;
   gap: 1.25em 1.25em;
   padding: var(--size-6) var(--size-4);
@@ -40,6 +41,9 @@
 }
 
 .contact {
-  display: flex;
-  flex-direction: column;
+  text-align: center;
+}
+.contact a {
+  margin-inline: 1em;
+  
 }

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -32,11 +32,8 @@ const Signup = () => {
     message: "",
   })
   const [sluggedName, setSluggedName] = useState()
+  const [firstSlugCheck, setFirstSlugCheck] = useState(false)
   const router = useRouter()
-
-  useEffect(() => {
-    setSluggedName(slugify(newUser.name, { lower: true }))
-  }, [newUser.name])
 
   const handleChange = (e) => {
     setNewUser({ ...newUser, [e.target.id]: e.target.value })
@@ -71,21 +68,25 @@ const Signup = () => {
   }
 
   const checkName = async (e) => {
-    if (newUser.name.length > 0) {
-      e.preventDefault()
-      // setSluggedName(slugify(newUser.name, { lower: true }))
+    e.preventDefault()
 
+    if (firstSlugCheck == false) {
+      setFirstSlugCheck(true)
+    }
+
+    if (sluggedName.length > 0) {
+      setSluggedName(slugify(sluggedName))
       let { data, error } = await supabase
         .from("profiles")
         .select("*")
         .eq("slug", sluggedName)
 
       if (data.length > 0) {
-        setNamesTaken({ color: "red", message: "Names taken, try again" })
+        setNamesTaken({ color: "red", message: "Urls taken, try again" })
       } else if (data.length == 0) {
         setNamesTaken({
           color: "green",
-          message: "This name is available, snag it!",
+          message: "This url is available, snag it!",
         })
       }
 
@@ -103,7 +104,7 @@ const Signup = () => {
           type: newUser.type,
           username: newUser.name,
           location: newUser.location,
-          slug: slugify(newUser.name, { lower: true }),
+          slug: sluggedName,
         },
       },
     })
@@ -246,32 +247,42 @@ const Signup = () => {
                     id="name"
                     type="text"
                     value={newUser.name}
-                    onFocus={() =>
-                      setNamesTaken({ color: "transparent", message: "" })
+                    onInput={
+                      firstSlugCheck
+                        ? null
+                        : (e) =>
+                            setSluggedName(
+                              slugify(e.target.value, { lower: true })
+                            )
                     }
-                    onBlur={checkName}
+                    onBlur={firstSlugCheck ? null : checkName}
                     required
                   />
                 </div>
+
+                <div className="input-wrapper">
+                  <label htmlFor="slug">Label slug</label>
+                  <input
+                    className="input"
+                    onChange={(e) => setSluggedName(e.target.value)}
+                    id="slug"
+                    type="text"
+                    value={
+                      sluggedName
+                        ? slugify(sluggedName, { lower: true, trim: false })
+                        : sluggedName
+                    }
+                    onBlur={checkName}
+                  />
+                </div>
                 <small>
-                  Public Address: {process.env.NEXT_PUBLIC_DLCM_URL}
+                  Public address: {process.env.NEXT_PUBLIC_DLCM_URL}
                   {`${sluggedName}`}
                 </small>
                 <br />
                 <small style={{ color: `${namesTaken.color}` }}>
                   {namesTaken.message}
                 </small>
-
-                <div className="input-wrapper">
-                  <label htmlFor="location">Label location</label>
-                  <input
-                    className="input"
-                    onChange={handleChange}
-                    id="location"
-                    type="text"
-                    value={newUser.location}
-                  />
-                </div>
               </>
             ) : (
               <>
@@ -283,11 +294,32 @@ const Signup = () => {
                     id="name"
                     type="text"
                     value={newUser.name}
-                    onFocus={() =>
-                      setNamesTaken({ color: "transparent", message: "" })
+                    onInput={
+                      firstSlugCheck
+                        ? null
+                        : (e) =>
+                            setSluggedName(
+                              slugify(e.target.value, { lower: true })
+                            )
+                    }
+                    onBlur={firstSlugCheck ? null : checkName}
+                    required
+                  />
+                </div>
+
+                <div className="input-wrapper">
+                  <label htmlFor="slug">Artist slug</label>
+                  <input
+                    className="input"
+                    onChange={(e) => setSluggedName(e.target.value)}
+                    id="slug"
+                    type="text"
+                    value={
+                      sluggedName
+                        ? slugify(sluggedName, { lower: true, trim: false })
+                        : sluggedName
                     }
                     onBlur={checkName}
-                    required
                   />
                 </div>
                 <small>
@@ -298,17 +330,6 @@ const Signup = () => {
                 <small style={{ color: `${namesTaken.color}` }}>
                   {namesTaken.message}
                 </small>
-
-                <div className="input-wrapper">
-                  <label htmlFor="location">Artist location</label>
-                  <input
-                    className="input"
-                    onChange={handleChange}
-                    id="location"
-                    type="text"
-                    value={newUser.location}
-                  />
-                </div>
               </>
             )}
             <div className="button-actions inline-wrap">


### PR DESCRIPTION
This PR allows users to create a custom slug on user creation.

When a user enters their label/band name, a slug is automatically generated for them. On blur, it will then check if that slug is available and inform the user.

If the slug is in use, the user will be able to edit the slug until they find something they like and is available.

Altering the username will have no effect on the slug after initial blur.

This is also implemented for updating your profile, though a user must be subscribed in order to use this feature.

I do think this presents some issues. The main one being that if a user changes their slug, there is currently no way to create redirects for any of their fans that go to their old URL.

Will implement this same functionality on create release next. I do not think you should be able to change a releases name after creation, though.