### PR TITLE
Subscribe page and DLCM friend logic

### DIFF
--- a/components/Account/Account.jsx
+++ b/components/Account/Account.jsx
@@ -56,7 +56,9 @@ export default function Account({ session }) {
             {profileData.type}
           </div>
           <div className="badge">
-            {profileData.is_subscribed ? "Pro User" : "Free User"}
+            {profileData.is_subscribed || profileData.dlcm_friend
+              ? "Pro User"
+              : "Free User"}
           </div>
 
           <h1>{profileData.username}</h1>
@@ -76,18 +78,20 @@ export default function Account({ session }) {
             setShowUpdateView={setShowUpdateView}
           />
 
-          {profileData.is_subscribed ? (
-            <Link
-              style={{ display: "block" }}
-              href="/api/stripe-customer-portal"
-            >
-              Manage Subscription
-            </Link>
-          ) : (
-            <Link style={{ display: "block" }} href="/api/subscribe-to-dlcm">
-              Subscribe
-            </Link>
-          )}
+          {!profileData.dlcm_friend ? (
+            profileData.is_subscribed ? (
+              <Link
+                style={{ display: "block" }}
+                href="/api/stripe-customer-portal"
+              >
+                Manage Subscription
+              </Link>
+            ) : (
+              <Link style={{ display: "block" }} href="/api/subscribe-to-dlcm">
+                Subscribe
+              </Link>
+            )
+          ) : null}
         </div>
       </article>
 

--- a/components/Account/Account.jsx
+++ b/components/Account/Account.jsx
@@ -52,7 +52,7 @@ export default function Account({ session }) {
       <article className={cn(styles.profile, "inline-wrap")}>
         <Avatar url={profileData.avatar_url} size={100} />
         <div className={styles.details}>
-          <div style={{ "margin-inline-end": "1em" }} className="badge">
+          <div style={{ marginInlineEnd: "1em" }} className="badge">
             {profileData.type}
           </div>
           <div className="badge">

--- a/components/AddCodes/AddCodes.jsx
+++ b/components/AddCodes/AddCodes.jsx
@@ -99,7 +99,7 @@ export default function AddCodes({
             rows="8"
             onChange={(e) => setCodes(e.target.value.split(/\s/g))}
           ></textarea>
-          {profileData.is_subscribed ? (
+          {profileData.is_subscribed || profileData.dlcm_friend ? (
             <>
               <label className="label" htmlFor="csvcodes">
                 Upload with Bandcamp CSV

--- a/components/Releases/CreateRelease.jsx
+++ b/components/Releases/CreateRelease.jsx
@@ -275,7 +275,7 @@ export default function CreateRelease({
               </option>
             ))}
           </select>
-          {profileData.is_subscribed ? (
+          {profileData.is_subscribed || profileData.dlcm_friend ? (
             <>
               <label className="label" htmlFor="apple">
                 Apple Music Link

--- a/components/Releases/Releases.jsx
+++ b/components/Releases/Releases.jsx
@@ -45,7 +45,7 @@ export default function Releases({ profileData }) {
     <article className="stack">
       <header className="article-heading inline-wrap">
         <h2>Releases</h2>
-        {profileData.is_subscribed ? (
+        {profileData.is_subscribed || profileData.dlcm_friend ? (
           <CreateRelease
             setAddedNewRelease={setAddedNewRelease}
             profileData={profileData}
@@ -75,7 +75,9 @@ export default function Releases({ profileData }) {
         {releases.length ? (
           <>
             {releases.map((release, index) =>
-              profileData.is_subscribed || index <= 1 ? (
+              profileData.is_subscribed ||
+              profileData.dlcm_friend ||
+              index <= 1 ? (
                 <ReleaseCard
                   key={release.id}
                   release={release}
@@ -90,7 +92,9 @@ export default function Releases({ profileData }) {
               className={cn(styles.actionCard, "container")}
               data-variant="empty"
             >
-              {profileData.is_subscribed || releases.length <= 1 ? (
+              {profileData.is_subscribed ||
+              profileData.dlcm_friend ||
+              releases.length <= 1 ? (
                 <CreateRelease
                   setAddedNewRelease={setAddedNewRelease}
                   profileData={profileData}

--- a/components/Releases/UpdateRelease.jsx
+++ b/components/Releases/UpdateRelease.jsx
@@ -178,7 +178,7 @@ export default function UpdateRelease({
             value={yumUrl}
             onChange={(e) => setYumUrl(e.target.value)}
           />
-          {profileData.is_subscribed ? (
+          {profileData.is_subscribed || profileData.dlcm_friend ? (
             <>
               <label className="label" htmlFor="apple">
                 Apple Music Link

--- a/components/UpdateProfile/UpdateProfile.jsx
+++ b/components/UpdateProfile/UpdateProfile.jsx
@@ -213,7 +213,7 @@ export default function UpdateProfile({
             This is the link your customers will visit to redeem their code. It
             is usually &quot;your-name.bandcamp/yum&quot;
           </small>
-          {profileData.is_subscribed ? (
+          {profileData.is_subscribed || profileData.dlcm_friend ? (
             <>
               <label className="label" htmlFor="apple">
                 Apple Music Link

--- a/components/UpdateProfile/UpdateProfile.jsx
+++ b/components/UpdateProfile/UpdateProfile.jsx
@@ -155,7 +155,7 @@ export default function UpdateProfile({
             onChange={(e) => setUsername(e.target.value)}
             required
           />
-          {profileData.is_subscribed ? (
+          {profileData.is_subscribed || profileData.dlcm_friend ? (
             <>
               <label className="label" htmlFor="slug">
                 {profileData.type.charAt(0).toUpperCase() +

--- a/pages/api/subscribe-to-dlcm.js
+++ b/pages/api/subscribe-to-dlcm.js
@@ -31,7 +31,7 @@ const handler = async (req, res) => {
       },
     ],
     success_url: "https://unrivaled-pie-1255ea.netlify.app/payment/success",
-    cancel_url: "https://unrivaled-pie-1255ea.netlify.app/payment/cancel",
+    cancel_url: "https://unrivaled-pie-1255ea.netlify.app/payment/cancelled",
   })
 
   res.redirect(stripeSession.url)

--- a/pages/api/subscribe-to-dlcm.js
+++ b/pages/api/subscribe-to-dlcm.js
@@ -15,16 +15,14 @@ const handler = async (req, res) => {
       description:
         "The user does not have an active session or is not authenticated",
     })
-  const {
-    data: { stripe_customer_id },
-  } = await supabase
+  const { data: profileData } = await supabase
     .from("profiles")
     .select("stripe_customer_id")
     .eq("id", session.user.id)
     .single()
 
   const stripeSession = await stripe.checkout.sessions.create({
-    customer: stripe_customer_id,
+    customer: profileData.stripe_customer_id,
     mode: "subscription",
     line_items: [
       {

--- a/pages/subscribe.js
+++ b/pages/subscribe.js
@@ -1,20 +1,26 @@
+import { useUser } from "@supabase/auth-helpers-react"
+import Link from "next/link"
+
 export default function Subscribe() {
+  const user = useUser()
+
   return (
     <article
       className="container stack inline-max center-stage"
       style={{ "--max-inline-size": "400px" }}
     >
       <h1>Subscribe to DLCM</h1>
+      <h2>Pro Plan</h2>
       <div
         className="container"
         style={{
           textAlign: "center",
           fontSize: 40,
           fontWeight: 600,
-          paddingBlock: 75,
+          paddingBlock: 60,
         }}
       >
-        $5
+        $5 a month
       </div>
       <div className="perks">
         <ul role="list">
@@ -25,6 +31,18 @@ export default function Subscribe() {
           <li>Bandcamp CSV Code Upload</li>
           <li>Social Site Links</li>
         </ul>
+      </div>
+
+      <div className="subscribe-link" style={{ textAlign: "center" }}>
+        {user ? (
+          <Link style={{ display: "block" }} href="/api/subscribe-to-dlcm">
+            Subscribe
+          </Link>
+        ) : (
+          <Link style={{ display: "block" }} href="/signup">
+            Create an account to subscribe
+          </Link>
+        )}
       </div>
     </article>
   )

--- a/pages/subscribe.js
+++ b/pages/subscribe.js
@@ -1,0 +1,31 @@
+export default function Subscribe() {
+  return (
+    <article
+      className="container stack inline-max center-stage"
+      style={{ "--max-inline-size": "400px" }}
+    >
+      <h1>Subscribe to DLCM</h1>
+      <div
+        className="container"
+        style={{
+          textAlign: "center",
+          fontSize: 40,
+          fontWeight: 600,
+          paddingBlock: 75,
+        }}
+      >
+        $5
+      </div>
+      <div className="perks">
+        <ul role="list">
+          <li>Unlimited Releases</li>
+          <li>Custom URLs</li>
+          <li>Password Protect Releases & Public Profile</li>
+          <li>Turn Releases On/Off</li>
+          <li>Bandcamp CSV Code Upload</li>
+          <li>Social Site Links</li>
+        </ul>
+      </div>
+    </article>
+  )
+}

--- a/pages/subscribe.js
+++ b/pages/subscribe.js
@@ -35,8 +35,8 @@ export default function Subscribe() {
 
       <div className="subscribe-link" style={{ textAlign: "center" }}>
         {user ? (
-          <Link style={{ display: "block" }} href="/api/subscribe-to-dlcm">
-            Subscribe
+          <Link style={{ display: "block" }} href="/">
+            Subscribe from your user dashboard
           </Link>
         ) : (
           <Link style={{ display: "block" }} href="/signup">


### PR DESCRIPTION
This PR introduces a subscription information page. It shows all of the perks you receive when signing up. If you are already a user, it will tell you to subscribe from your dashboard, and if you are not a registered user, it will ask you to sign up.

Also implemented DLCM friend logic. This is for our legacy users. They will have full pro access for being with us from the beginning. Because of this, any mention of a subscription on their page is hidden so as to not have them accidentally sign up.