### PR TITLE
various form styling updates

### DIFF
--- a/components/Account/Account.jsx
+++ b/components/Account/Account.jsx
@@ -54,12 +54,13 @@ export default function Account({ session }) {
           <Avatar url={profileData.avatar_url} size={100} />
           <div className={styles.details}>
             <div style={{ marginInlineEnd: "1em" }} className="badge">
-              {profileData.type}
+              {profileData.type.charAt(0).toUpperCase() +
+                profileData.type.slice(1)}
             </div>
             <div className="badge">
               {profileData.is_subscribed || profileData.dlcm_friend
-                ? "Pro User"
-                : "Free User"}
+                ? "Pro user"
+                : "Free user"}
             </div>
 
             <h1>{profileData.username}</h1>
@@ -84,13 +85,20 @@ export default function Account({ session }) {
           {!profileData.dlcm_friend ? (
             profileData.is_subscribed ? (
               <Link
-                style={{ display: "block" }}
+                className="button"
+                data-variant="primary"
+                style={{ display: "block", textDecoration: "none" }}
                 href="/api/stripe-customer-portal"
               >
-                Manage Subscription
+                Manage subscription
               </Link>
             ) : (
-              <Link style={{ display: "block" }} href="/api/subscribe-to-dlcm">
+              <Link
+                className="button"
+                data-variant="primary"
+                style={{ display: "block", textDecoration: "none" }}
+                href="/api/subscribe-to-dlcm"
+              >
                 Subscribe
               </Link>
             )

--- a/components/Layout/Layout.jsx
+++ b/components/Layout/Layout.jsx
@@ -1,11 +1,18 @@
 import { useUser, useSupabaseClient } from "@supabase/auth-helpers-react"
 import Link from "next/link"
 import styles from "./Layout.module.css"
+import { useRouter } from "next/router"
 
 export default function Layout({ children }) {
   const supabase = useSupabaseClient()
   const user = useUser()
   const date = new Date()
+  const router = useRouter()
+
+  async function signOut() {
+    await supabase.auth.signOut()
+    router.push("/")
+  }
 
   return (
     <>
@@ -37,9 +44,9 @@ export default function Layout({ children }) {
                   <button
                     className="button"
                     data-size="small"
-                    onClick={() => supabase.auth.signOut()}
+                    onClick={signOut}
                   >
-                    Sign Out
+                    Log Out
                   </button>
                 </li>
               </ul>

--- a/components/Login/Login.module.css
+++ b/components/Login/Login.module.css
@@ -13,7 +13,7 @@
   padding-inline: var(--size-5);
   font-weight: 600;
   font-size: 1.25rem;
-  width: 50ch;
+  max-inline-size: "50ch";
  
   align-items: center;
 }

--- a/components/Releases/CreateRelease.jsx
+++ b/components/Releases/CreateRelease.jsx
@@ -337,24 +337,32 @@ export default function CreateRelease({
                   setSites({ ...sites, [e.target.id]: e.target.value })
                 }
               />
-              <label className="label" htmlFor="isActive">
-                Allow fans to access?
-              </label>
-              <input
-                id="isActive"
-                type="checkbox"
-                checked={isActive}
-                onChange={() => setIsActive(!isActive)}
-              />
-              <label className="label" htmlFor="passwordProtect">
-                Password protect page?
-              </label>
-              <input
-                id="passwordProtect"
-                type="checkbox"
-                checked={isPasswordProtected}
-                onChange={() => setIsPasswordProtected(!isPasswordProtected)}
-              />{" "}
+              <div style={{ display: "flex" }}>
+                <label className="label" htmlFor="isActive">
+                  Show Release?
+                </label>
+                <input
+                  className="input"
+                  style={{ inlineSize: "50%", width: "20%" }}
+                  id="isActive"
+                  type="checkbox"
+                  checked={isActive}
+                  onChange={() => setIsActive(!isActive)}
+                />
+              </div>
+              <div style={{ display: "flex" }}>
+                <label className="label" htmlFor="passwordProtect">
+                  Password protect page?
+                </label>
+                <input
+                  className="input"
+                  style={{ inlineSize: "50%", width: "20%" }}
+                  id="passwordProtect"
+                  type="checkbox"
+                  checked={isPasswordProtected}
+                  onChange={() => setIsPasswordProtected(!isPasswordProtected)}
+                />{" "}
+              </div>
               {isPasswordProtected ? (
                 <>
                   <label className="label" htmlFor="pagePassword">

--- a/components/Releases/UpdateRelease.jsx
+++ b/components/Releases/UpdateRelease.jsx
@@ -240,24 +240,32 @@ export default function UpdateRelease({
                   setSites({ ...sites, [e.target.id]: e.target.value })
                 }
               />
-              <label className="label" htmlFor="isActive">
-                Allow fans to access?
-              </label>
-              <input
-                id="isActive"
-                type="checkbox"
-                checked={isActive}
-                onChange={() => setIsActive(!isActive)}
-              />
-              <label className="label" htmlFor="passwordProtect">
-                Password protect page?
-              </label>
-              <input
-                id="passwordProtect"
-                type="checkbox"
-                checked={isPasswordProtected}
-                onChange={() => setIsPasswordProtected(!isPasswordProtected)}
-              />{" "}
+              <div style={{ display: "flex" }}>
+                <label className="label" htmlFor="isActive">
+                  Show Release?
+                </label>
+                <input
+                  className="input"
+                  style={{ inlineSize: "50%", width: "20%" }}
+                  id="isActive"
+                  type="checkbox"
+                  checked={isActive}
+                  onChange={() => setIsActive(!isActive)}
+                />
+              </div>
+              <div style={{ display: "flex" }}>
+                <label className="label" htmlFor="passwordProtect">
+                  Password protect release?
+                </label>
+                <input
+                  className="input"
+                  style={{ inlineSize: "50%", width: "20%" }}
+                  id="passwordProtect"
+                  type="checkbox"
+                  checked={isPasswordProtected}
+                  onChange={() => setIsPasswordProtected(!isPasswordProtected)}
+                />{" "}
+              </div>
               {isPasswordProtected ? (
                 <>
                   <label className="label" htmlFor="pagePassword">

--- a/components/UpdateProfile/UpdateProfile.jsx
+++ b/components/UpdateProfile/UpdateProfile.jsx
@@ -10,6 +10,7 @@ import {
   DialogClose,
 } from "@/components/Dialog/Dialog"
 import PopoverTip from "../PopoverTip/PopoverTip"
+import Link from "next/link"
 
 export default function UpdateProfile({
   getProfile,
@@ -131,7 +132,7 @@ export default function UpdateProfile({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger className="button" data-variant="primary">
-        Update Profile
+        Update profile
       </DialogTrigger>
 
       <DialogContent>
@@ -197,6 +198,14 @@ export default function UpdateProfile({
           <small style={{ color: `${namesTaken.color}` }}>
             {namesTaken.message}
           </small>
+          <Link
+            className="button"
+            data-variant="primary"
+            style={{ textDecoration: "none" }}
+            href="/reset-password"
+          >
+            Change your password
+          </Link>
           <label className="label" htmlFor="location">
             Location
           </label>
@@ -287,16 +296,20 @@ export default function UpdateProfile({
                   setSites({ ...sites, [e.target.id]: e.target.value })
                 }
               />
+              <div style={{ display: "flex" }}>
+                <label className="label" htmlFor="passwordProtect">
+                  Password protect profile page?
+                </label>
 
-              <input
-                id="passwordProtect"
-                type="checkbox"
-                checked={isPasswordProtected}
-                onChange={() => setIsPasswordProtected(!isPasswordProtected)}
-              />
-              <label className="label" htmlFor="passwordProtect">
-                Password protect page?
-              </label>
+                <input
+                  className="input"
+                  style={{ inlineSize: "50%", width: "20%" }}
+                  id="passwordProtect"
+                  type="checkbox"
+                  checked={isPasswordProtected}
+                  onChange={() => setIsPasswordProtected(!isPasswordProtected)}
+                />
+              </div>
 
               {isPasswordProtected ? (
                 <>


### PR DESCRIPTION
This PR fixes styling issues in the update profile, create release, and update release forms, as well as issues with the home page copy and casing throughout the app.

In update profile, a change password link has been added, as well as styling to put the check box for password protect page inline. The copy has also been changed to Password protect profile page, for clarity.

Create and Update release have both had the same styling fixes for Show release and Password protect release. The copy has been changed as well.

The home page about section font has been changed to prevent overflow.

Clicking sign out will now automatically send you to the log in page. The copy has also been changed to Log Out.