### PR TITLE
started implementing filter releases

### DIFF
--- a/components/Profile/Profile.jsx
+++ b/components/Profile/Profile.jsx
@@ -22,6 +22,26 @@ export default function ProfileLayout({
     isPasswordProtected ? false : true
   )
   const [showError, setShowError] = useState(false)
+  const [sortedReleases, setSortedReleases] = useState(releases)
+
+  const handleSort = (value) => {
+    let arr
+
+    if (value === "created oldest first") {
+      arr = [...releases].sort((a, b) => (a.created_at > b.created_at ? 1 : -1))
+    }
+    if (value === "created newest first") {
+      arr = [...releases].sort((a, b) => (a.created_at < b.created_at ? 1 : -1))
+    }
+    if (value === "alphabetical a to z") {
+      arr = [...releases].sort((a, b) => (a.title > b.title ? 1 : -1))
+    }
+    if (value === "alphabetical z to a") {
+      arr = [...releases].sort((a, b) => (a.title < b.title ? 1 : -1))
+    }
+
+    setSortedReleases(arr)
+  }
 
   function handleSubmit(e) {
     e.preventDefault()
@@ -103,17 +123,37 @@ export default function ProfileLayout({
             </form>
           </div>
         ) : (
-          <ul className="grid" role="list">
-            {releases.map((release) =>
-              release.is_active ? (
-                <ReleaseCard
-                  key={release.id}
-                  release={release}
-                  profileSlug={profileSlug}
-                />
-              ) : null
-            )}
-          </ul>
+          <>
+            <div className={styles.filter}>
+              <label className="label" htmlFor="order">
+                Order
+              </label>
+
+              <select
+                className="select"
+                id="order"
+                onChange={(e) => handleSort(e.target.value)}
+              >
+                <option value="created oldest first" selected>
+                  Oldest First
+                </option>
+                <option value="created newest first">Newest First</option>
+                <option value="alphabetical a to z">A to Z</option>
+                <option value="alphabetical z to a">Z to A</option>
+              </select>
+            </div>
+            <ul className="grid" role="list">
+              {sortedReleases.map((release) =>
+                release.is_active ? (
+                  <ReleaseCard
+                    key={release.id}
+                    release={release}
+                    profileSlug={profileSlug}
+                  />
+                ) : null
+              )}
+            </ul>
+          </>
         )}
       </>
     </>

--- a/components/Profile/Profile.module.css
+++ b/components/Profile/Profile.module.css
@@ -24,6 +24,15 @@
   justify-content: center;
 }
 
+.filter {
+  display: flex;
+  align-items: center;
+}
+
+.filter select {
+  margin-inline-start: 1em;
+}
+
 @media screen and (max-width: 480px) {
   .profile img {
     height: 100px;

--- a/components/Releases/Releases.jsx
+++ b/components/Releases/Releases.jsx
@@ -13,11 +13,34 @@ export default function Releases({ profileData }) {
   const [releases, setReleases] = useState([])
   const [allowNew, setAllowNew] = useState(true)
   const [addedNewRelease, setAddedNewRelease] = useState(false)
+  const [filter, setFilter] = useState("oldest")
 
   useEffect(() => {
     getReleases()
     setAddedNewRelease(false)
   }, [supabase, profileData.id, addedNewRelease])
+
+  useEffect(() => {
+    if (releases) {
+      let sortedReleases = releases
+      if (filter === "alphabetical") {
+        sortedReleases.sort((a, b) => {
+          let titleOne = a.title.toLowerCase()
+          let titleTwo = b.title.toLowerCase()
+
+          if (titleOne < titleTwo) {
+            return -1
+          }
+          if (titleOne > titleTwo) {
+            return 1
+          }
+          return 0
+        })
+      }
+
+      setReleases(sortedReleases)
+    }
+  }, [filter])
 
   async function getReleases() {
     try {
@@ -45,6 +68,14 @@ export default function Releases({ profileData }) {
     <article className="stack">
       <header className="article-heading inline-wrap">
         <h2>Releases</h2>
+        <div className={styles.filter}>
+          <button
+            className="button"
+            data-variant="primary"
+            type="button"
+            onClick={() => setFilter("alphabetical")}
+          >{`a -> z`}</button>
+        </div>
         {profileData.is_subscribed || profileData.dlcm_friend ? (
           <CreateRelease
             setAddedNewRelease={setAddedNewRelease}

--- a/components/Releases/Releases.jsx
+++ b/components/Releases/Releases.jsx
@@ -13,34 +13,30 @@ export default function Releases({ profileData }) {
   const [releases, setReleases] = useState([])
   const [allowNew, setAllowNew] = useState(true)
   const [addedNewRelease, setAddedNewRelease] = useState(false)
-  const [filter, setFilter] = useState("oldest")
 
   useEffect(() => {
     getReleases()
     setAddedNewRelease(false)
   }, [supabase, profileData.id, addedNewRelease])
 
-  useEffect(() => {
-    if (releases) {
-      let sortedReleases = releases
-      if (filter === "alphabetical") {
-        sortedReleases.sort((a, b) => {
-          let titleOne = a.title.toLowerCase()
-          let titleTwo = b.title.toLowerCase()
+  const handleSort = (value) => {
+    let arr
 
-          if (titleOne < titleTwo) {
-            return -1
-          }
-          if (titleOne > titleTwo) {
-            return 1
-          }
-          return 0
-        })
-      }
-
-      setReleases(sortedReleases)
+    if (value === "created oldest first") {
+      arr = [...releases].sort((a, b) => (a.created_at > b.created_at ? 1 : -1))
     }
-  }, [filter])
+    if (value === "created newest first") {
+      arr = [...releases].sort((a, b) => (a.created_at < b.created_at ? 1 : -1))
+    }
+    if (value === "alphabetical a to z") {
+      arr = [...releases].sort((a, b) => (a.title > b.title ? 1 : -1))
+    }
+    if (value === "alphabetical z to a") {
+      arr = [...releases].sort((a, b) => (a.title < b.title ? 1 : -1))
+    }
+
+    setReleases(arr)
+  }
 
   async function getReleases() {
     try {
@@ -69,12 +65,22 @@ export default function Releases({ profileData }) {
       <header className="article-heading inline-wrap">
         <h2>Releases</h2>
         <div className={styles.filter}>
-          <button
-            className="button"
-            data-variant="primary"
-            type="button"
-            onClick={() => setFilter("alphabetical")}
-          >{`a -> z`}</button>
+          <label className="label" htmlFor="order">
+            Order
+          </label>
+
+          <select
+            className="select"
+            id="order"
+            onChange={(e) => handleSort(e.target.value)}
+          >
+            <option value="created oldest first" selected>
+              Oldest First
+            </option>
+            <option value="created newest first">Newest First</option>
+            <option value="alphabetical a to z">A to Z</option>
+            <option value="alphabetical z to a">Z to A</option>
+          </select>
         </div>
         {profileData.is_subscribed || profileData.dlcm_friend ? (
           <CreateRelease

--- a/components/Releases/Releases.module.css
+++ b/components/Releases/Releases.module.css
@@ -19,3 +19,12 @@
 .actionCard:has(button:hover) {
   border-color: var(--link-hover);
 }
+
+.filter {
+  display: flex;
+  align-items: center;
+}
+
+.filter select {
+  margin-inline-start: 1em;
+}


### PR DESCRIPTION
This PR is going to introduce the ability to filter releases alphabetically, chronologically, or by artist (only if you are a label).

Currently, I have only started implementing alphabetical. The logic works, and you can see the state change in the dev tools, but it does not reflect the change on screen. I think this might be because by the time the filter fires off, the page has already been rendered. Meaning a solution could be to abstract the mapping of the releases to another component. This feels redundant, though I could be wrong.