### PR TITLE
Issues #91/101/103/108/110/111 addressed

### DIFF
--- a/components/Layout/Layout.jsx
+++ b/components/Layout/Layout.jsx
@@ -72,7 +72,7 @@ export default function Layout({ children }) {
                     href="/help"
                     style={{ textDecoration: "none" }}
                   >
-                    Docs
+                    FAQs
                   </Link>
                 </li>
               </ul>

--- a/components/Profile/Profile.jsx
+++ b/components/Profile/Profile.jsx
@@ -103,11 +103,17 @@ export default function ProfileLayout({
                 height={200}
               />
             )}
-            <div className={cn(styles.info, "stack")}>
+            <div className={cn(styles.info, "stack", "block-overflow")}>
               <div>
-                <h1>{name}</h1>
-                <h2>{location}</h2>
-                <h3>{aboutBlurb}</h3>
+                <div className={cn(styles.name)}>
+                  <h1>{name}</h1>
+                </div>
+                <div className={cn(styles.location)}>
+                  <h2>{location}</h2>
+                </div>
+                <div className={cn(styles.blurb)}>
+                  <p>{aboutBlurb}</p>
+                </div>
               </div>
               <SocialSites sites={sites} />
             </div>

--- a/components/Profile/Profile.jsx
+++ b/components/Profile/Profile.jsx
@@ -4,6 +4,7 @@ import cn from "classnames"
 import SocialSites from "../SocialSites/SocialSites"
 import { useState } from "react"
 import Head from "next/head"
+import Link from "next/link"
 
 const sortByCreatedAt = (a, b) => (a.created_at > b.created_at ? 1 : -1)
 const sortByTitle = (a, b) => (a.title > b.title ? 1 : -1)
@@ -165,13 +166,24 @@ export default function ProfileLayout({
               </div>
             ) : null}
             <ul className="grid" role="list">
-              {sortedReleases.map((release) =>
+              {sortedReleases.map((release, index) =>
                 release.is_active ? (
-                  <ReleaseCard
-                    key={release.id}
-                    release={release}
-                    profileSlug={profileSlug}
-                  />
+                  <li key={index}>
+                    <Link
+                      className={styles.release}
+                      href={`/${profileSlug}/${release.release_slug}`}
+                      style={{
+                        textDecoration: "none",
+                        color: "var(--text-1)",
+                      }}
+                    >
+                      <ReleaseCard
+                        key={release.id}
+                        release={release}
+                        profileSlug={profileSlug}
+                      />
+                    </Link>
+                  </li>
                 ) : null
               )}
             </ul>

--- a/components/Profile/Profile.jsx
+++ b/components/Profile/Profile.jsx
@@ -115,7 +115,7 @@ export default function ProfileLayout({
                   <p>{aboutBlurb}</p>
                 </div>
               </div>
-              <SocialSites sites={sites} />
+              <SocialSites sites={sites} isSubscribed={isSubscribed} />
             </div>
           </div>
         </div>

--- a/components/Profile/Profile.jsx
+++ b/components/Profile/Profile.jsx
@@ -9,10 +9,20 @@ const sortByCreatedAt = (a, b) => (a.created_at > b.created_at ? 1 : -1)
 const sortByTitle = (a, b) => (a.title > b.title ? 1 : -1)
 
 const filterOptions = [
-  { "label": "Oldest First", "value": "oldest", "method": sortByCreatedAt, "direction": "asc" },
-  { "label": "Newest First", "value": "newest", "method": sortByCreatedAt, "direction": "desc" },
-  { "label": "A to Z", "value": "a-z", "method": sortByTitle, "direction": "asc" },
-  { "label": "Z to A", "value": "z-a", "method": sortByTitle, "direction": "desc" }
+  {
+    label: "Oldest First",
+    value: "oldest",
+    method: sortByCreatedAt,
+    direction: "asc",
+  },
+  {
+    label: "Newest First",
+    value: "newest",
+    method: sortByCreatedAt,
+    direction: "desc",
+  },
+  { label: "A to Z", value: "a-z", method: sortByTitle, direction: "asc" },
+  { label: "Z to A", value: "z-a", method: sortByTitle, direction: "desc" },
 ]
 
 export default function ProfileLayout({
@@ -25,6 +35,7 @@ export default function ProfileLayout({
   pagePassword,
   isPasswordProtected,
   aboutBlurb,
+  isSubscribed,
 }) {
   const [artwork, setArtwork] = useState(avatar)
   const [password, setPassword] = useState()
@@ -35,13 +46,13 @@ export default function ProfileLayout({
   const [sortedReleases, setSortedReleases] = useState(releases)
 
   const handleSort = (value) => {
-    const selected = filterOptions.find(option => option.value === value);
-    let sortedItems;
+    const selected = filterOptions.find((option) => option.value === value)
+    let sortedItems
 
     sortedItems = [...releases].sort(selected.method)
 
     if (selected.direction === "desc") {
-      sortedItems.reverse();
+      sortedItems.reverse()
     }
 
     setSortedReleases(sortedItems)
@@ -128,23 +139,25 @@ export default function ProfileLayout({
           </div>
         ) : (
           <>
-            <div className={styles.filter}>
-              <label className="label" htmlFor="order">
-                Order
-              </label>
-              <select
-                className="input select"
-                style={{ inlineSize: "auto" }}
-                id="order"
-                onChange={(e) => handleSort(e.target.value)}
-              >
-                {filterOptions.map(({ label, value }) => (
-                  <option value={value} key={value}>
-                    {label}
-                  </option> 
-                ))}
-              </select>
-            </div>
+            {isSubscribed ? (
+              <div className={styles.filter}>
+                <label className="label" htmlFor="order">
+                  Order
+                </label>
+                <select
+                  className="input select"
+                  style={{ inlineSize: "auto" }}
+                  id="order"
+                  onChange={(e) => handleSort(e.target.value)}
+                >
+                  {filterOptions.map(({ label, value }) => (
+                    <option value={value} key={value}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            ) : null}
             <ul className="grid" role="list">
               {sortedReleases.map((release) =>
                 release.is_active ? (

--- a/components/Profile/Profile.module.css
+++ b/components/Profile/Profile.module.css
@@ -11,12 +11,23 @@
 
 }
 
+
 .info {
   display: flex;
-  flex-direction: column;
-  
-  }
+  flex-direction: column; 
+}
 
+.name {
+  font-size: clamp(.75rem, 2vw, var(--size-4));
+}
+
+.location {
+  font-size: clamp(.5rem, 2vw, var(--size-3));
+}
+.blurb {
+  font-size: clamp(.75rem, 2vw, var(--size-4));
+  
+}
 .wrapper {
   display: flex;
   flex-direction: column;
@@ -34,16 +45,24 @@
 }
 
 @media screen and (max-width: 480px) {
+  .profile {
+    flex-direction: column;
+  }
   .profile img {
     height: 100px;
     width: 100px;
   }
 
-  .info h1 {
+  /* .info h1 {
     font-size: 28px;
   }
 
-  .info h2 h3 {
+  .info h2{
     font-size: 20px;
-  }
+  } */
+
+  /* .blurb {
+    height: 8.8vh;
+    overflow-y: scroll;
+  } */
 }

--- a/components/Profile/Profile.module.css
+++ b/components/Profile/Profile.module.css
@@ -22,7 +22,7 @@
 }
 
 .location {
-  font-size: clamp(.5rem, 2vw, var(--size-3));
+  font-size: clamp(.75rem, 2vw, var(--size-3));
 }
 .blurb {
   font-size: clamp(.75rem, 2vw, var(--size-4));
@@ -53,16 +53,5 @@
     width: 100px;
   }
 
-  /* .info h1 {
-    font-size: 28px;
-  }
-
-  .info h2{
-    font-size: 20px;
-  } */
-
-  /* .blurb {
-    height: 8.8vh;
-    overflow-y: scroll;
-  } */
+ 
 }

--- a/components/Profile/Profile.module.css
+++ b/components/Profile/Profile.module.css
@@ -10,8 +10,14 @@
   gap: 25px;
 
 }
-
-
+/* .release {
+  text-decoration: none;
+  color: var(--text-1);
+} */
+.release :hover {
+  color: var(--link-hover);
+  border-color: var(--brand-1-hover);
+}
 .info {
   display: flex;
   flex-direction: column; 

--- a/components/Releases/CreateRelease.jsx
+++ b/components/Releases/CreateRelease.jsx
@@ -240,21 +240,6 @@ export default function CreateRelease({
             onChange={(e) => setArtworkUrl(e.target.value)}
           />
           <p>Upload an image or paste an external link</p>*/}
-          <label className="label" htmlFor="yumUrl">
-            Redemption{`(yum)`} Link
-          </label>
-          <input
-            className="input"
-            id="yumUrl"
-            type="text"
-            value={yumUrl}
-            onChange={(e) => setYumUrl(e.target.value)}
-          />
-          <small>
-            This is the link your customers will visit to redeem their code. It
-            is usually &quot;your-name.bandcamp/yum&quot;
-          </small>
-
           <label className="label" htmlFor="type">
             Type
           </label>
@@ -275,6 +260,34 @@ export default function CreateRelease({
               </option>
             ))}
           </select>
+          <h3>You must include https:// in your links</h3>
+          <label className="label" htmlFor="yumUrl">
+            Redemption{`(yum)`} Link
+          </label>
+          <input
+            className="input"
+            id="yumUrl"
+            type="text"
+            value={yumUrl}
+            onChange={(e) => setYumUrl(e.target.value)}
+          />
+          <small>
+            This is the link your customers will visit to redeem their code. It
+            is usually &quot;your-name.bandcamp/yum&quot;
+          </small>
+
+          <label className="label" htmlFor="bandcamp">
+            Bandcamp Link
+          </label>
+          <input
+            className="input"
+            id="bandcamp"
+            type="text"
+            value={sites.bandcamp}
+            onChange={(e) =>
+              setSites({ ...sites, [e.target.id]: e.target.value })
+            }
+          />
           {profileData.is_subscribed || profileData.dlcm_friend ? (
             <>
               <label className="label" htmlFor="apple">
@@ -289,18 +302,7 @@ export default function CreateRelease({
                   setSites({ ...sites, [e.target.id]: e.target.value })
                 }
               />
-              <label className="label" htmlFor="bandcamp">
-                Bandcamp Link
-              </label>
-              <input
-                className="input"
-                id="bandcamp"
-                type="text"
-                value={sites.bandcamp}
-                onChange={(e) =>
-                  setSites({ ...sites, [e.target.id]: e.target.value })
-                }
-              />
+
               <label className="label" htmlFor="spotify">
                 Spotify Link
               </label>

--- a/components/Releases/ReleaseCard.jsx
+++ b/components/Releases/ReleaseCard.jsx
@@ -31,7 +31,7 @@ export default function ReleaseCard({
   }, [onCodeAdded])
 
   return (
-    <li className={styles.component}>
+    <div className={styles.component}>
       <div className={styles.content}>
         {artwork ? (
           <Link href={`/${profileSlug}/${release.release_slug}`}>
@@ -92,6 +92,6 @@ export default function ReleaseCard({
           </div>
         ) : null
       ) : null}
-    </li>
+    </div>
   )
 }

--- a/components/Releases/ReleaseLayout.jsx
+++ b/components/Releases/ReleaseLayout.jsx
@@ -5,7 +5,7 @@ import styles from "./ReleaseLayout.module.css"
 import cn from "classnames"
 import Head from "next/head"
 
-export default function ReleaseLayout({ release }) {
+export default function ReleaseLayout({ release, isSubscribed }) {
   const [password, setPassword] = useState()
   const [authorized, setAuthorized] = useState(
     release.is_password_protected ? false : true
@@ -63,12 +63,18 @@ export default function ReleaseLayout({ release }) {
             )}
             <div className={cn(styles.info, "stack")}>
               <div>
-                <h1>{release.title}</h1>
-                <h2>{release.artist}</h2>
-                <h3>{release.label}</h3>
+                <div className={styles.title}>
+                  <h1>{release.title}</h1>
+                </div>
+                <div className={styles.artist}>
+                  <h2>{release.artist}</h2>
+                </div>
+                <div className={styles.label}>
+                  <h3>{release.label}</h3>
+                </div>
                 <p>{release.type}</p>
               </div>
-              <SocialSites sites={release.sites} />
+              <SocialSites sites={release.sites} isSubscribed={isSubscribed} />
             </div>
           </div>
           {!authorized ? (

--- a/components/Releases/ReleaseLayout.module.css
+++ b/components/Releases/ReleaseLayout.module.css
@@ -14,6 +14,16 @@ flex-direction: column;
 
 }
 
+.title {
+  font-size: clamp(.75rem, 2vw, var(--size-4));
+}
+
+.artist {
+  font-size: clamp(.75rem, 2vw, var(--size-3));
+}
+.label {
+  font-size: clamp(.75rem, 2vw, var(--size-3));
+}
 .codes {
   margin-block: 40px;
   display: flex;
@@ -30,14 +40,5 @@ flex-direction: column;
     height: 100px;
     width: 100px;
   }
-  .info h1 {
-    font-size: 24px;
-  }
-  .info h2 {
-    font-size: 18px;
-  }
-
-  .info p {
-    font-size: 14px;
-  }
+ 
 }

--- a/components/Releases/Releases.jsx
+++ b/components/Releases/Releases.jsx
@@ -11,10 +11,20 @@ const sortByCreatedAt = (a, b) => (a.created_at > b.created_at ? 1 : -1)
 const sortByTitle = (a, b) => (a.title > b.title ? 1 : -1)
 
 const filterOptions = [
-  { "label": "Oldest First", "value": "oldest", "method": sortByCreatedAt, "direction": "asc" },
-  { "label": "Newest First", "value": "newest", "method": sortByCreatedAt, "direction": "desc" },
-  { "label": "A to Z", "value": "a-z", "method": sortByTitle, "direction": "asc" },
-  { "label": "Z to A", "value": "z-a", "method": sortByTitle, "direction": "desc" }
+  {
+    label: "Oldest First",
+    value: "oldest",
+    method: sortByCreatedAt,
+    direction: "asc",
+  },
+  {
+    label: "Newest First",
+    value: "newest",
+    method: sortByCreatedAt,
+    direction: "desc",
+  },
+  { label: "A to Z", value: "a-z", method: sortByTitle, direction: "asc" },
+  { label: "Z to A", value: "z-a", method: sortByTitle, direction: "desc" },
 ]
 
 export default function Releases({ profileData }) {
@@ -30,13 +40,13 @@ export default function Releases({ profileData }) {
   }, [supabase, profileData.id, addedNewRelease])
 
   const handleSort = (value) => {
-    const selected = filterOptions.find(option => option.value === value);
-    let sortedItems;
+    const selected = filterOptions.find((option) => option.value === value)
+    let sortedItems
 
     sortedItems = [...releases].sort(selected.method)
 
     if (selected.direction === "desc") {
-      sortedItems.reverse();
+      sortedItems.reverse()
     }
 
     setReleases(sortedItems)
@@ -68,23 +78,25 @@ export default function Releases({ profileData }) {
     <article className="stack">
       <header className="article-heading inline-wrap">
         <h2>Releases</h2>
-        <div className={styles.filter}>
-          <label className="label" htmlFor="order">
-            Order
-          </label>
+        {profileData.is_subscribed ? (
+          <div className={styles.filter}>
+            <label className="label" htmlFor="order">
+              Order
+            </label>
 
-          <select
-            className="input select"
-            id="order"
-            onChange={(e) => handleSort(e.target.value)}
-          >
-            {filterOptions.map(({ label, value }) => (
-              <option value={value} key={value}>
-                {label}
-              </option> 
-            ))}
-          </select>
-        </div>
+            <select
+              className="input select"
+              id="order"
+              onChange={(e) => handleSort(e.target.value)}
+            >
+              {filterOptions.map(({ label, value }) => (
+                <option value={value} key={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : null}
         {profileData.is_subscribed || profileData.dlcm_friend ? (
           <CreateRelease
             setAddedNewRelease={setAddedNewRelease}

--- a/components/Releases/UpdateRelease.jsx
+++ b/components/Releases/UpdateRelease.jsx
@@ -264,17 +264,6 @@ export default function UpdateRelease({
           <small style={{ color: `${namesTaken.color}` }}>
             {namesTaken.message}
           </small>
-
-          <label className="label" htmlFor="yumUrl">
-            Redemption Link
-          </label>
-          <input
-            className="input"
-            id="yumUrl"
-            type="text"
-            value={yumUrl}
-            onChange={(e) => setYumUrl(e.target.value)}
-          />
           <label className="label" htmlFor="type">
             Type
           </label>
@@ -295,6 +284,28 @@ export default function UpdateRelease({
               </option>
             ))}
           </select>
+          <label className="label" htmlFor="yumUrl">
+            Redemption Link
+          </label>
+          <input
+            className="input"
+            id="yumUrl"
+            type="text"
+            value={yumUrl}
+            onChange={(e) => setYumUrl(e.target.value)}
+          />
+          <label className="label" htmlFor="bandcamp">
+            Bandcamp Link
+          </label>
+          <input
+            className="input"
+            id="bandcamp"
+            type="text"
+            value={sites.bandcamp}
+            onChange={(e) =>
+              setSites({ ...sites, [e.target.id]: e.target.value })
+            }
+          />
           {profileData.is_subscribed || profileData.dlcm_friend ? (
             <>
               <label className="label" htmlFor="apple">
@@ -309,18 +320,7 @@ export default function UpdateRelease({
                   setSites({ ...sites, [e.target.id]: e.target.value })
                 }
               />
-              <label className="label" htmlFor="bandcamp">
-                Bandcamp Link
-              </label>
-              <input
-                className="input"
-                id="bandcamp"
-                type="text"
-                value={sites.bandcamp}
-                onChange={(e) =>
-                  setSites({ ...sites, [e.target.id]: e.target.value })
-                }
-              />
+
               <label className="label" htmlFor="spotify">
                 Spotify Link
               </label>

--- a/components/SocialSites/SocialSites.jsx
+++ b/components/SocialSites/SocialSites.jsx
@@ -8,7 +8,7 @@ import {
   faItunesNote,
 } from "@fortawesome/free-brands-svg-icons"
 
-export default function SocialSites({ sites }) {
+export default function SocialSites({ sites, isSubscribed }) {
   let showSites = false
 
   Object.values(sites).forEach((site) => {
@@ -26,61 +26,79 @@ export default function SocialSites({ sites }) {
       <div className={styles.sites}>
         <p>Listen</p>
         <ul>
-          {sites.bandcamp ? (
-            <li className="bandcamp">
-              <a href={`${sites.bandcamp}`}>
-                <FontAwesomeIcon
-                  icon={faBandcamp}
-                  size={iconSize}
-                  color="#3B98AA"
-                />
-              </a>
-            </li>
-          ) : null}
-          {sites.apple ? (
-            <li className="apple">
-              <a href={`${sites.apple}`}>
-                <FontAwesomeIcon
-                  icon={faItunesNote}
-                  size={iconSize}
-                  color="#FF354D"
-                />
-              </a>
-            </li>
-          ) : null}
-          {sites.spotify ? (
-            <li className="spotify">
-              <a href={`${sites.spotify}`}>
-                <FontAwesomeIcon
-                  icon={faSpotify}
-                  size={iconSize}
-                  color="#1DD461"
-                />
-              </a>
-            </li>
-          ) : null}
-          {sites.soundcloud ? (
-            <li className="soundcloud">
-              <a href={`${sites.soundcloud}`}>
-                <FontAwesomeIcon
-                  icon={faSoundcloud}
-                  size={iconSize}
-                  color="#FE8A23"
-                />
-              </a>
-            </li>
-          ) : null}
-          {sites.youtube ? (
-            <li className="youtube">
-              <a href={`${sites.youtube}`}>
-                <FontAwesomeIcon
-                  icon={faYoutube}
-                  size={iconSize}
-                  color="#FE0100"
-                />
-              </a>
-            </li>
-          ) : null}
+          {isSubscribed ? (
+            <>
+              {sites.bandcamp ? (
+                <li className="bandcamp">
+                  <a href={`${sites.bandcamp}`}>
+                    <FontAwesomeIcon
+                      icon={faBandcamp}
+                      size={iconSize}
+                      color="#3B98AA"
+                    />
+                  </a>
+                </li>
+              ) : null}
+              {sites.apple ? (
+                <li className="apple">
+                  <a href={`${sites.apple}`}>
+                    <FontAwesomeIcon
+                      icon={faItunesNote}
+                      size={iconSize}
+                      color="#FF354D"
+                    />
+                  </a>
+                </li>
+              ) : null}
+              {sites.spotify ? (
+                <li className="spotify">
+                  <a href={`${sites.spotify}`}>
+                    <FontAwesomeIcon
+                      icon={faSpotify}
+                      size={iconSize}
+                      color="#1DD461"
+                    />
+                  </a>
+                </li>
+              ) : null}
+              {sites.soundcloud ? (
+                <li className="soundcloud">
+                  <a href={`${sites.soundcloud}`}>
+                    <FontAwesomeIcon
+                      icon={faSoundcloud}
+                      size={iconSize}
+                      color="#FE8A23"
+                    />
+                  </a>
+                </li>
+              ) : null}
+              {sites.youtube ? (
+                <li className="youtube">
+                  <a href={`${sites.youtube}`}>
+                    <FontAwesomeIcon
+                      icon={faYoutube}
+                      size={iconSize}
+                      color="#FE0100"
+                    />
+                  </a>
+                </li>
+              ) : null}
+            </>
+          ) : (
+            <>
+              {sites.bandcamp ? (
+                <li className="bandcamp">
+                  <a href={`${sites.bandcamp}`}>
+                    <FontAwesomeIcon
+                      icon={faBandcamp}
+                      size={iconSize}
+                      color="#3B98AA"
+                    />
+                  </a>
+                </li>
+              ) : null}
+            </>
+          )}
         </ul>
       </div>
     </>

--- a/components/UpdateProfile/UpdateProfile.jsx
+++ b/components/UpdateProfile/UpdateProfile.jsx
@@ -251,6 +251,18 @@ export default function UpdateProfile({
             This is the link your customers will visit to redeem their code. It
             is usually &quot;your-name.bandcamp/yum&quot;
           </small>
+          <label className="label" htmlFor="bandcamp">
+            Bandcamp Link
+          </label>
+          <input
+            className="input"
+            id="bandcamp"
+            type="text"
+            value={sites.bandcamp}
+            onChange={(e) =>
+              setSites({ ...sites, [e.target.id]: e.target.value })
+            }
+          />
           {profileData.is_subscribed || profileData.dlcm_friend ? (
             <>
               <label className="label" htmlFor="apple">
@@ -261,19 +273,6 @@ export default function UpdateProfile({
                 id="apple"
                 type="text"
                 value={sites.apple}
-                onChange={(e) =>
-                  setSites({ ...sites, [e.target.id]: e.target.value })
-                }
-              />
-
-              <label className="label" htmlFor="bandcamp">
-                Bandcamp Link
-              </label>
-              <input
-                className="input"
-                id="bandcamp"
-                type="text"
-                value={sites.bandcamp}
                 onChange={(e) =>
                   setSites({ ...sites, [e.target.id]: e.target.value })
                 }

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -26,6 +26,7 @@ export default function ProfilePage({ profile, params }) {
         pagePassword={profile.page_password}
         isPasswordProtected={profile.is_password_protected}
         aboutBlurb={profile.about_blurb}
+        isSubscribed={profile.is_subscribed}
       />
     ) : (
       <div>Loading...</div>

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -39,7 +39,7 @@ export default function ProfilePage({ profile, params }) {
       release.release_slug == params.slug[1] ? (album = release) : null
     )
     return profile && album ? (
-      <ReleaseLayout release={album} />
+      <ReleaseLayout release={album} isSubscribed={profile.is_subscribed} />
     ) : (
       <div>No Release Found</div>
     )

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -5,6 +5,8 @@ import slugify from "slugify"
 import { useRouter } from "next/router"
 import PopoverTip from "@/components/PopoverTip/PopoverTip"
 import Head from "next/head"
+import cn from "classnames"
+import styles from "../components/Login/Login.module.css"
 
 const accountTypes = [
   { value: "", label: "Choose account type", disabled: true },
@@ -394,6 +396,42 @@ const Signup = () => {
           </div>
         )}
       </article>
+      <section className={cn(styles.subscription, "stack")}>
+        <h2>Subscribe to DLCM</h2>
+        <div className={styles.plans}>
+          <section className={cn(styles.free, "container", "stack")}>
+            <h2>Free Plan</h2>
+            <div className={styles.perks}>
+              <ul role="list">
+                <li>Two Releases</li>
+                <li>Unlimited Codes</li>
+              </ul>
+            </div>
+          </section>
+
+          <section className={cn(styles.pro, "container", "stack")}>
+            <h2>Pro Plan</h2>
+            <div className={styles.cost}>
+              <p>$5/mth</p>
+              <p>or</p>
+              <p>
+                $50/yr <small>{`(Save $10)`}</small>
+              </p>
+            </div>
+            <div className={styles.perks}>
+              <ul role="list">
+                <li>Unlimited Releases</li>
+                <li>Custom URLs</li>
+                <li>Release Level URLs</li>
+                <li>Password Protected Pages</li>
+                <li>Turn Releases On/Off</li>
+                <li>Bandcamp CSV Code Upload</li>
+                <li>Social/Streaming Links</li>
+              </ul>
+            </div>
+          </section>
+        </div>
+      </section>
     </>
   )
 }


### PR DESCRIPTION
This Pull request fixes the following issues:

91 - Added subscription info to the signup link. This still needs to be styled better. I don't love the plans stacked in a column. Should be side by side. Will address this when we alter the copy.

101 - Change Docs to FAQs when user not logged in. I had already fixed when logged in, this was a miss that is now fixed.

103 - Made entire release card clickable when viewing a user profile. Added a hover effect to denote it is clickable.

108 - Added the ability to input and display bandcamp link for free plans.

110 - Fixed about section in mobile view. Could possibly still be better, but is good for now.

111 - Removed sort feature for free plan users.