### PR TITLE
update release url and release type bug fixes

### DIFF
--- a/components/Releases/CreateRelease.jsx
+++ b/components/Releases/CreateRelease.jsx
@@ -60,6 +60,10 @@ export default function CreateRelease({
 
   const checkName = async (e) => {
     e.preventDefault()
+    if (sluggedName.length == 0) {
+      setNamesTaken({ color: "red", message: "Release must have a slug" })
+      setNoGO(true)
+    }
     if (sluggedName.length > 0) {
       if (firstSlugCheck == false) {
         setFirstSlugCheck(true)
@@ -400,7 +404,7 @@ export default function CreateRelease({
                 isPasswordProtected,
               })
             }
-            disabled={!title && !artist && type != releaseTypes[5].text && noGO}
+            disabled={!title || type == releaseTypes[5].text || noGO}
           >
             Create
           </button>

--- a/components/Releases/UpdateRelease.jsx
+++ b/components/Releases/UpdateRelease.jsx
@@ -33,7 +33,9 @@ export default function UpdateRelease({
   const user = useUser()
   const [open, setOpen] = useState(false)
   const [title, setTitle] = useState(release.title)
-  const [sluggedName, setSluggedName] = useState(slugify(release.title))
+  const [sluggedName, setSluggedName] = useState(
+    release.release_slug ?? slugify(release.title)
+  )
   const [namesTaken, setNamesTaken] = useState({
     color: "transparent",
     message: "",

--- a/components/Releases/UpdateRelease.jsx
+++ b/components/Releases/UpdateRelease.jsx
@@ -63,6 +63,10 @@ export default function UpdateRelease({
 
   const checkName = async (e) => {
     e.preventDefault()
+    if (sluggedName.length == 0) {
+      setNamesTaken({ color: "red", message: "Release must have a slug" })
+      setNoGO(true)
+    }
     if (sluggedName.length > 0) {
       if (firstSlugCheck == false) {
         setFirstSlugCheck(true)
@@ -410,6 +414,7 @@ export default function UpdateRelease({
               data-variant="primary"
               onClick={updateRelease}
               style={{ marginInlineEnd: "1em" }}
+              disabled={sluggedName.length == 0}
             >
               Update
             </button>

--- a/components/UpdateProfile/UpdateProfile.jsx
+++ b/components/UpdateProfile/UpdateProfile.jsx
@@ -48,7 +48,10 @@ export default function UpdateProfile({
 
   const checkName = async (e) => {
     e.preventDefault()
-
+    if (sluggedName.length == 0) {
+      setNamesTaken({ color: "red", message: "Profile must have a slug" })
+      setNoGo(true)
+    }
     if (sluggedName.length > 0) {
       setSluggedName(slugify(sluggedName))
       if (sluggedName == profileData.slug) {

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -80,7 +80,10 @@ const Signup = () => {
     if (firstSlugCheck == false) {
       setFirstSlugCheck(true)
     }
-
+    if (sluggedName.length == 0) {
+      setNamesTaken({ color: "red", message: "User must have a slug" })
+      setNoGO(true)
+    }
     if (sluggedName.length > 0) {
       setSluggedName(slugify(sluggedName))
       let { data, error } = await supabase


### PR DESCRIPTION
This PR fixes two bugs.

The first was having the updated release slug properly display on refresh.

The second was being able to create a release without a type defined.