### PR TITLE
fixed create release bug and profile order issue

### DIFF
--- a/components/Login/Login.jsx
+++ b/components/Login/Login.jsx
@@ -28,7 +28,7 @@ export default function Login() {
   return (
     <>
       <Head>
-        <title>Log in to DLCM</title>
+        <title>{"Log in to DLCM"}</title>
         <meta property="og:title" content="Log in to DLCM" key="title" />
         <meta
           property="og:description"

--- a/components/Profile/Profile.jsx
+++ b/components/Profile/Profile.jsx
@@ -73,7 +73,7 @@ export default function ProfileLayout({
   return (
     <>
       <Head>
-        <title>{name}&apos;s public profile</title>
+        <title>{`${name}'s public profile`}</title>
         <meta
           property="og:title"
           content={`${name}'s public profile`}

--- a/components/Releases/CreateRelease.jsx
+++ b/components/Releases/CreateRelease.jsx
@@ -58,6 +58,30 @@ export default function CreateRelease({
     youtube: null,
   })
 
+  const resetForm = () => {
+    setTitle()
+    setSluggedName("")
+    setFirstSlugCheck(false)
+    setNoGO(true)
+    setArtworkUrl()
+    setPagePassword()
+    setIsPasswordProtected(false)
+    setType(releaseTypes[5].text)
+    setNewImagePath()
+    setIsActive(true)
+    setNamesTaken({
+      color: "transparent",
+      message: "",
+    })
+    setSites({
+      apple: null,
+      spotify: null,
+      bandcamp: null,
+      soundcloud: null,
+      youtube: null,
+    })
+  }
+
   const checkName = async (e) => {
     e.preventDefault()
     if (sluggedName.length == 0) {
@@ -124,8 +148,8 @@ export default function CreateRelease({
     } catch (error) {
       alert("Error creating new release!")
     } finally {
-      console.log("All done!")
       setAddedNewRelease(true)
+      resetForm()
       setOpen(false)
     }
   }
@@ -141,6 +165,7 @@ export default function CreateRelease({
         throw error
       }
     }
+    resetForm()
     setOpen(false)
   }
 

--- a/components/Releases/UpdateRelease.jsx
+++ b/components/Releases/UpdateRelease.jsx
@@ -61,6 +61,30 @@ export default function UpdateRelease({
     youtube: release.sites.youtube ? release.sites.youtube : null,
   })
 
+  const resetForm = () => {
+    setTitle(release.title)
+    setSluggedName(release.release_slug ?? slugify(release.title))
+    setFirstSlugCheck(false)
+    setNoGO(true)
+    setArtworkUrl(release.artwork_url)
+    setPagePassword(release.page_password)
+    setIsPasswordProtected(release.is_password_protected)
+    setType(release.type)
+    setNewImagePath()
+    setIsActive(release.is_active)
+    setNamesTaken({
+      color: "transparent",
+      message: "",
+    })
+    setSites({
+      apple: release.sites.apple ? release.sites.apple : null,
+      spotify: release.sites.spotify ? release.sites.spotify : null,
+      bandcamp: release.sites.bandcamp ? release.sites.bandcamp : null,
+      soundcloud: release.sites.soundcloud ? release.sites.soundcloud : null,
+      youtube: release.sites.youtube ? release.sites.youtube : null,
+    })
+  }
+
   const checkName = async (e) => {
     e.preventDefault()
     if (sluggedName.length == 0) {
@@ -133,6 +157,7 @@ export default function UpdateRelease({
       getReleases()
       setShowReleaseUpdateView(false)
       alert("Release updated!")
+      resetForm()
       setOpen(false)
     }
   }
@@ -148,6 +173,7 @@ export default function UpdateRelease({
         throw error
       }
     }
+    resetForm()
     setOpen(false)
   }
 

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -8,6 +8,7 @@ export async function getServerSideProps({ params }) {
     .select("*, releases(*, codes(*))")
     .eq("slug", params.slug[0])
     .eq("releases.codes.redeemed", false)
+    .order("created_at", { foreignTable: "releases", ascending: true })
     .single()
 
   return { props: { profile, params } }

--- a/pages/help.js
+++ b/pages/help.js
@@ -8,7 +8,7 @@ export default function Help() {
   return (
     <>
       <Head>
-        <title>DLCM FAQs</title>
+        <title>{"DLCM FAQs"}</title>
         <meta property="og:title" content="DLCM FAQs" key="title" />
         <meta
           property="og:description"

--- a/pages/privacy.js
+++ b/pages/privacy.js
@@ -11,7 +11,7 @@ export default function PrivacyPolicy() {
   return (
     <>
       <Head>
-        <title>Sign up to DLCM</title>
+        <title>{"Sign up to DLCM"}</title>
         <meta property="og:title" content="Sign up to DLCM" key="title" />
         <meta
           property="og:description"

--- a/pages/request-password-reset.js
+++ b/pages/request-password-reset.js
@@ -23,7 +23,7 @@ export default function RequestPasswordReset() {
   return (
     <>
       <Head>
-        <title>Password reset</title>
+        <title>{"Password reset"}</title>
         <meta
           property="og:title"
           content="Request a password reset"

--- a/pages/reset-password.js
+++ b/pages/reset-password.js
@@ -52,7 +52,7 @@ export default function ResetPassword() {
   return (
     <>
       <Head>
-        <title>Update your password</title>
+        <title>{"Update your password"}</title>
         <meta property="og:title" content="Update your password" key="title" />
         <meta
           property="og:description"

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -151,7 +151,7 @@ const Signup = () => {
   return (
     <>
       <Head>
-        <title>Sign up to DLCM</title>
+        <title>{"Sign up to DLCM"}</title>
         <meta property="og:title" content="Sign up to DLCM" key="title" />
         <meta
           property="og:description"

--- a/pages/subscribe.js
+++ b/pages/subscribe.js
@@ -8,7 +8,7 @@ export default function Subscribe() {
   return (
     <>
       <Head>
-        <title>Subscribe to DLCM</title>
+        <title>{"Subscribe to DLCM"}</title>
         <meta property="og:title" content="Subscribe to DLCM" key="title" />
         <meta
           property="og:description"

--- a/pages/terms.js
+++ b/pages/terms.js
@@ -11,7 +11,7 @@ export default function Terms() {
   return (
     <>
       <Head>
-        <title>Terms and Conditions</title>
+        <title>{"Terms and Conditions"}</title>
         <meta property="og:title" content="Terms and Conditions" key="title" />
         <meta
           property="og:description"


### PR DESCRIPTION
This PR fixes the issue that kept the form data loaded in create release even after a release had been created. This would cause release images to be wrongfully deleted.

Added same logic to update release to prevent issues.

Also fixed logic so a users public profile will correctly sort orders on page load.