### PR TITLE
fixed update release error

### DIFF
--- a/components/Releases/ReleaseCard.jsx
+++ b/components/Releases/ReleaseCard.jsx
@@ -74,7 +74,7 @@ export default function ReleaseCard({
             <UpdateRelease
               setShowReleaseUpdateView={setShowReleaseUpdateView}
               release={release}
-              getReleases={getProfile}
+              getProfile={getProfile}
               profileData={profileData}
             />
             <AddCodes


### PR DESCRIPTION
This PR fixed an error that was introduced during the pagination update. I had forgotten to rename a prop, leading to releases being unable to be updated.