### PR TITLE
refactored social site input and is active into components

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,8 @@
   "cSpell.words": [
     "bandcamp",
     "dlcm",
+    "fontawesome",
+    "fortawesome",
     "soundcloud"
   ]
 }

--- a/components/InputIsActive/InputIsActive.jsx
+++ b/components/InputIsActive/InputIsActive.jsx
@@ -1,0 +1,14 @@
+export default function InputIsActive({ isActive, setIsActive, children }) {
+  return (
+    <label className="label checkbox" htmlFor="isActive">
+      <input
+        className="input"
+        id="isActive"
+        type="checkbox"
+        checked={isActive}
+        onChange={() => setIsActive(!isActive)}
+      />
+      {children}
+    </label>
+  )
+}

--- a/components/InputReleaseType/InputReleaseType.jsx
+++ b/components/InputReleaseType/InputReleaseType.jsx
@@ -3,8 +3,11 @@ const releaseTypes = [
   { id: 1, text: "LP" },
   { id: 2, text: "EP" },
   { id: 3, text: "Single" },
-  { id: 4, text: "Compilation" },
-  { id: 5, text: "Soundtrack" },
+  { id: 4, text: "Sample Pack" },
+  { id: 5, text: "Compilation" },
+  { id: 6, text: "Soundtrack" },
+  { id: 7, text: "Mixtape" },
+  { id: 8, text: "Demo" },
 ]
 
 export default function InputReleaseType({ type, onChange }) {

--- a/components/InputSocialSites/InputSocialSites.jsx
+++ b/components/InputSocialSites/InputSocialSites.jsx
@@ -6,7 +6,9 @@ export default function InputSocialSites({
   setSites,
   isSubscribed,
   isDlcmFriend,
+  showPersonal,
 }) {
+  const [personalUrl, setPersonalUrl] = useState(sites?.personal ?? null)
   const [bandcampUrl, setBandcampUrl] = useState(sites?.bandcamp ?? null)
   const [appleMusicUrl, setAppleMusicUrl] = useState(sites?.apple ?? null)
   const [spotifyUrl, setSpotifyUrl] = useState(sites?.spotify ?? null)
@@ -15,15 +17,37 @@ export default function InputSocialSites({
 
   useEffect(() => {
     setSites({
+      personal: personalUrl ? prependProtocol(personalUrl) : null,
       bandcamp: bandcampUrl ? prependProtocol(bandcampUrl) : null,
       apple: appleMusicUrl ? prependProtocol(appleMusicUrl) : null,
       spotify: spotifyUrl ? prependProtocol(spotifyUrl) : null,
       soundcloud: soundcloudUrl ? prependProtocol(soundcloudUrl) : null,
       youtube: youtubeUrl ? prependProtocol(youtubeUrl) : null,
     })
-  }, [bandcampUrl, appleMusicUrl, spotifyUrl, soundcloudUrl, youtubeUrl])
+  }, [
+    bandcampUrl,
+    appleMusicUrl,
+    spotifyUrl,
+    soundcloudUrl,
+    youtubeUrl,
+    personalUrl,
+  ])
   return (
     <>
+      {showPersonal ? (
+        <>
+          <label className="label" htmlFor="personal">
+            Website
+          </label>
+          <input
+            className="input"
+            id="personal"
+            type="url"
+            value={personalUrl}
+            onChange={(e) => setPersonalUrl(e.target.value)}
+          />
+        </>
+      ) : null}
       <label className="label" htmlFor="bandcamp">
         Bandcamp Link
       </label>

--- a/components/InputSocialSites/InputSocialSites.jsx
+++ b/components/InputSocialSites/InputSocialSites.jsx
@@ -1,0 +1,85 @@
+import { prependProtocol } from "@/utils/utils"
+import { useEffect, useState } from "react"
+
+export default function InputSocialSites({
+  sites,
+  setSites,
+  isSubscribed,
+  isDlcmFriend,
+}) {
+  const [bandcampUrl, setBandcampUrl] = useState(sites?.bandcamp ?? null)
+  const [appleMusicUrl, setAppleMusicUrl] = useState(sites?.apple ?? null)
+  const [spotifyUrl, setSpotifyUrl] = useState(sites?.spotify ?? null)
+  const [soundcloudUrl, setSoundcloudUrl] = useState(sites?.soundcloud ?? null)
+  const [youtubeUrl, setYoutubeUrl] = useState(sites?.youtube ?? null)
+
+  useEffect(() => {
+    setSites({
+      bandcamp: bandcampUrl ? prependProtocol(bandcampUrl) : null,
+      apple: appleMusicUrl ? prependProtocol(appleMusicUrl) : null,
+      spotify: spotifyUrl ? prependProtocol(spotifyUrl) : null,
+      soundcloud: soundcloudUrl ? prependProtocol(soundcloudUrl) : null,
+      youtube: youtubeUrl ? prependProtocol(youtubeUrl) : null,
+    })
+  }, [bandcampUrl, appleMusicUrl, spotifyUrl, soundcloudUrl, youtubeUrl])
+  return (
+    <>
+      <label className="label" htmlFor="bandcamp">
+        Bandcamp Link
+      </label>
+      <input
+        className="input"
+        id="bandcamp"
+        type="url"
+        value={bandcampUrl}
+        required
+        onChange={(e) => setBandcampUrl(e.target.value)}
+      />
+      {isSubscribed || isDlcmFriend ? (
+        <>
+          <label className="label" htmlFor="apple">
+            Apple Music Link
+          </label>
+          <input
+            className="input"
+            id="apple"
+            type="url"
+            value={appleMusicUrl}
+            onChange={(e) => setAppleMusicUrl(e.target.value)}
+          />
+
+          <label className="label" htmlFor="spotify">
+            Spotify Link
+          </label>
+          <input
+            className="input"
+            id="spotify"
+            type="url"
+            value={spotifyUrl}
+            onChange={(e) => setSpotifyUrl(e.target.value)}
+          />
+          <label className="label" htmlFor="soundcloud">
+            Soundcloud Link
+          </label>
+          <input
+            className="input"
+            id="soundcloud"
+            type="url"
+            value={soundcloudUrl}
+            onChange={(e) => setSoundcloudUrl(e.target.value)}
+          />
+          <label className="label" htmlFor="youtube">
+            YouTube Link
+          </label>
+          <input
+            className="input"
+            id="youtube"
+            type="url"
+            value={youtubeUrl}
+            onChange={(e) => setYoutubeUrl(e.target.value)}
+          />
+        </>
+      ) : null}
+    </>
+  )
+}

--- a/components/InputSocialSites/InputSocialSites.jsx
+++ b/components/InputSocialSites/InputSocialSites.jsx
@@ -4,9 +4,9 @@ import { useEffect, useState } from "react"
 export default function InputSocialSites({
   sites,
   setSites,
-  isSubscribed,
-  isDlcmFriend,
+  hasProAccount,
   showPersonal,
+  labelArtist,
 }) {
   const [personalUrl, setPersonalUrl] = useState(sites?.personal ?? null)
   const [bandcampUrl, setBandcampUrl] = useState(sites?.bandcamp ?? null)
@@ -37,7 +37,10 @@ export default function InputSocialSites({
       {showPersonal ? (
         <>
           <label className="label" htmlFor="personal">
-            Website
+            {labelArtist} site{" "}
+            <span>
+              <small>(This makes your logo a link)</small>
+            </span>
           </label>
           <input
             className="input"
@@ -59,7 +62,7 @@ export default function InputSocialSites({
         required
         onChange={(e) => setBandcampUrl(e.target.value)}
       />
-      {isSubscribed || isDlcmFriend ? (
+      {hasProAccount ? (
         <>
           <label className="label" htmlFor="apple">
             Apple Music Link

--- a/components/Profile/Profile.jsx
+++ b/components/Profile/Profile.jsx
@@ -33,6 +33,16 @@ export default function ProfileLayout({
   const endOffset = releasesOffset + releasesPerPage
   const currentReleases = refinedReleases.slice(releasesOffset, endOffset)
 
+  const profilePic = (
+    <Image
+      className={styles.avatar}
+      src={avatar || "/default-image.png"}
+      alt={name}
+      width={200}
+      height={200}
+    />
+  )
+
   const handlePageClick = () => {
     filtersRef.current?.scrollIntoView({ behavior: "smooth" })
   }
@@ -73,23 +83,9 @@ export default function ProfileLayout({
 
       <div className={cn(styles.wrapper, "stack inline-max")}>
         {sites.personal ? (
-          <Link href={sites.personal}>
-            <Image
-              className={styles.avatar}
-              src={avatar || "/default-image.png"}
-              alt={name}
-              width={200}
-              height={200}
-            />
-          </Link>
+          <Link href={sites.personal}>{profilePic}</Link>
         ) : (
-          <Image
-            className={styles.avatar}
-            src={avatar || "/default-image.png"}
-            alt={name}
-            width={200}
-            height={200}
-          />
+          profilePic
         )}
         <div className={cn(styles.info, "stack")}>
           <h1 className={cn(styles.name, "text-3")}>{name}</h1>

--- a/components/Profile/Profile.jsx
+++ b/components/Profile/Profile.jsx
@@ -72,13 +72,25 @@ export default function ProfileLayout({
       </Head>
 
       <div className={cn(styles.wrapper, "stack inline-max")}>
-        <Image
-          className={styles.avatar}
-          src={avatar || "/default-image.png"}
-          alt={name}
-          width={200}
-          height={200}
-        />
+        {sites.personal ? (
+          <Link href={sites.personal}>
+            <Image
+              className={styles.avatar}
+              src={avatar || "/default-image.png"}
+              alt={name}
+              width={200}
+              height={200}
+            />
+          </Link>
+        ) : (
+          <Image
+            className={styles.avatar}
+            src={avatar || "/default-image.png"}
+            alt={name}
+            width={200}
+            height={200}
+          />
+        )}
         <div className={cn(styles.info, "stack")}>
           <h1 className={cn(styles.name, "text-3")}>{name}</h1>
           <p className={cn(styles.location, "text-2")}>{location}</p>

--- a/components/Releases/CreateRelease.jsx
+++ b/components/Releases/CreateRelease.jsx
@@ -265,8 +265,7 @@ export default function CreateRelease({
           <InputSocialSites
             sites={sites}
             setSites={setSites}
-            isSubscribed={profileData.is_subscribed}
-            isDlcmFriend={profileData.dlcm_friend}
+            hasProAccount={profileData.is_subscribed || profileData.dlcm_friend}
           />
 
           {profileData.is_subscribed || profileData.dlcm_friend ? (

--- a/components/Releases/CreateRelease.jsx
+++ b/components/Releases/CreateRelease.jsx
@@ -13,6 +13,8 @@ import PopoverTip from "../PopoverTip/PopoverTip"
 import { prependProtocol } from "@/utils/utils"
 import InputPasswordProtect from "../InputPasswordProtect/InputPasswordProtect"
 import InputReleaseType from "../InputReleaseType/InputReleaseType"
+import InputSocialSites from "../InputSocialSites/InputSocialSites"
+import InputIsActive from "../InputIsActive/InputIsActive"
 
 export default function CreateRelease({
   trigger,
@@ -43,11 +45,7 @@ export default function CreateRelease({
   const [type, setType] = useState()
   const [newImagePath, setNewImagePath] = useState()
   const [isActive, setIsActive] = useState(true)
-  const [bandcampUrl, setBandcampUrl] = useState()
-  const [appleMusicUrl, setAppleMusicUrl] = useState()
-  const [spotifyUrl, setSpotifyUrl] = useState()
-  const [soundcloudUrl, setSoundcloudUrl] = useState()
-  const [youtubeUrl, setYoutubeUrl] = useState()
+  const [sites, setSites] = useState()
 
   const resetForm = () => {
     setTitle()
@@ -64,11 +62,7 @@ export default function CreateRelease({
       color: "transparent",
       message: "",
     })
-    setBandcampUrl(null)
-    setAppleMusicUrl(null)
-    setSpotifyUrl(null)
-    setSoundcloudUrl(null)
-    setYoutubeUrl(null)
+    setSites()
   }
 
   const checkName = async (e) => {
@@ -113,13 +107,7 @@ export default function CreateRelease({
         artwork_path: newImagePath,
         yum_url: prependProtocol(yumUrl),
         type: type,
-        sites: {
-          bandcamp: bandcampUrl ? prependProtocol(bandcampUrl) : null,
-          apple: appleMusicUrl ? prependProtocol(appleMusicUrl) : null,
-          spotify: spotifyUrl ? prependProtocol(spotifyUrl) : null,
-          soundcloud: soundcloudUrl ? prependProtocol(soundcloudUrl) : null,
-          youtube: youtubeUrl ? prependProtocol(youtubeUrl) : null,
-        },
+        sites: sites,
         is_active: isActive,
         is_password_protected: isPasswordProtected,
         release_slug: sluggedName,
@@ -258,6 +246,7 @@ export default function CreateRelease({
           <p>Upload an image or paste an external link</p>*/}
 
           <InputReleaseType type={type} onChange={setType} />
+
           <label className="label" htmlFor="yumUrl">
             Redemption (yum) Link
           </label>
@@ -273,69 +262,18 @@ export default function CreateRelease({
             is usually <code>your-name.bandcamp/yum</code>.
           </small>
 
-          <label className="label" htmlFor="bandcamp">
-            Bandcamp Link
-          </label>
-          <input
-            className="input"
-            id="bandcamp"
-            type="text"
-            value={bandcampUrl}
-            onChange={(e) => setBandcampUrl(e.target.value)}
+          <InputSocialSites
+            sites={sites}
+            setSites={setSites}
+            isSubscribed={profileData.is_subscribed}
+            isDlcmFriend={profileData.dlcm_friend}
           />
+
           {profileData.is_subscribed || profileData.dlcm_friend ? (
             <>
-              <label className="label" htmlFor="apple">
-                Apple Music Link
-              </label>
-              <input
-                className="input"
-                id="apple"
-                type="text"
-                value={appleMusicUrl}
-                onChange={(e) => setAppleMusicUrl(e.target.value)}
-              />
-
-              <label className="label" htmlFor="spotify">
-                Spotify Link
-              </label>
-              <input
-                className="input"
-                id="spotify"
-                type="text"
-                value={spotifyUrl}
-                onChange={(e) => setSpotifyUrl(e.target.value)}
-              />
-              <label className="label" htmlFor="soundcloud">
-                Soundcloud Link
-              </label>
-              <input
-                className="input"
-                id="soundcloud"
-                type="text"
-                value={soundcloudUrl}
-                onChange={(e) => setSoundcloudUrl(e.target.value)}
-              />
-              <label className="label" htmlFor="youtube">
-                YouTube Link
-              </label>
-              <input
-                className="input"
-                id="youtube"
-                type="text"
-                value={youtubeUrl}
-                onChange={(e) => setYoutubeUrl(e.target.value)}
-              />
-              <label className="label checkbox" htmlFor="isActive">
-                <input
-                  className="input"
-                  id="isActive"
-                  type="checkbox"
-                  checked={isActive}
-                  onChange={() => setIsActive(!isActive)}
-                />
+              <InputIsActive isActive={isActive} setIsActive={setIsActive}>
                 Show Release
-              </label>
+              </InputIsActive>
               <InputPasswordProtect
                 id="isPasswordProtected"
                 isProtected={isPasswordProtected}

--- a/components/Releases/UpdateRelease.jsx
+++ b/components/Releases/UpdateRelease.jsx
@@ -16,6 +16,8 @@ import slugify from "slugify"
 import { prependProtocol } from "@/utils/utils"
 import InputPasswordProtect from "../InputPasswordProtect/InputPasswordProtect"
 import InputReleaseType from "../InputReleaseType/InputReleaseType"
+import InputSocialSites from "../InputSocialSites/InputSocialSites"
+import InputIsActive from "../InputIsActive/InputIsActive"
 
 export default function UpdateRelease({
   release,
@@ -47,15 +49,7 @@ export default function UpdateRelease({
   const [newImagePath, setNewImagePath] = useState()
   const [isActive, setIsActive] = useState(release.is_active)
   const [type, setType] = useState(release.type)
-  const [bandcampUrl, setBandcampUrl] = useState(release.sites.bandcamp ?? null)
-  const [appleMusicUrl, setAppleMusicUrl] = useState(
-    release.sites.apple ?? null
-  )
-  const [spotifyUrl, setSpotifyUrl] = useState(release.sites.spotify ?? null)
-  const [soundcloudUrl, setSoundcloudUrl] = useState(
-    release.sites.soundcloud ?? null
-  )
-  const [youtubeUrl, setYoutubeUrl] = useState(release.sites.youtube ?? null)
+  const [sites, setSites] = useState(release.sites)
 
   const resetForm = () => {
     setTitle(release.title)
@@ -72,11 +66,7 @@ export default function UpdateRelease({
       color: "transparent",
       message: "",
     })
-    setBandcampUrl(release.sites.bandcamp ?? null)
-    setAppleMusicUrl(release.sites.apple ?? null)
-    setSpotifyUrl(release.sites.spotify ?? null)
-    setSoundcloudUrl(release.sites.soundcloud ?? null)
-    setYoutubeUrl(release.sites.youtube ?? null)
+    setSites(release.sites ?? null)
   }
 
   const checkName = async (e) => {
@@ -120,13 +110,7 @@ export default function UpdateRelease({
         artwork_path: newImagePath ? newImagePath : imagePath,
         yum_url: prependProtocol(yumUrl),
         type: type,
-        sites: {
-          bandcamp: bandcampUrl ? prependProtocol(bandcampUrl) : null,
-          apple: appleMusicUrl ? prependProtocol(appleMusicUrl) : null,
-          spotify: spotifyUrl ? prependProtocol(spotifyUrl) : null,
-          soundcloud: soundcloudUrl ? prependProtocol(soundcloudUrl) : null,
-          youtube: youtubeUrl ? prependProtocol(youtubeUrl) : null,
-        },
+        sites: sites,
         is_active: isActive,
         is_password_protected: isPasswordProtected,
         page_password: pagePassword,
@@ -312,68 +296,18 @@ export default function UpdateRelease({
             value={yumUrl}
             onChange={(e) => setYumUrl(e.target.value)}
           />
-          <label className="label" htmlFor="bandcamp">
-            Bandcamp Link
-          </label>
-          <input
-            className="input"
-            id="bandcamp"
-            type="text"
-            value={bandcampUrl}
-            onChange={(e) => setBandcampUrl(e.target.value)}
+
+          <InputSocialSites
+            sites={sites}
+            setSites={setSites}
+            isSubscribed={profileData.is_subscribed}
+            isDlcmFriend={profileData.dlcm_friend}
           />
           {profileData.is_subscribed || profileData.dlcm_friend ? (
             <>
-              <label className="label" htmlFor="apple">
-                Apple Music Link
-              </label>
-              <input
-                className="input"
-                id="apple"
-                type="text"
-                value={appleMusicUrl}
-                onChange={(e) => setAppleMusicUrl(e.target.value)}
-              />
-
-              <label className="label" htmlFor="spotify">
-                Spotify Link
-              </label>
-              <input
-                className="input"
-                id="spotify"
-                type="text"
-                value={spotifyUrl}
-                onChange={(e) => setSpotifyUrl(e.target.value)}
-              />
-              <label className="label" htmlFor="soundcloud">
-                Soundcloud Link
-              </label>
-              <input
-                className="input"
-                id="soundcloud"
-                type="text"
-                value={soundcloudUrl}
-                onChange={(e) => setSoundcloudUrl(e.target.value)}
-              />
-              <label className="label" htmlFor="youtube">
-                YouTube Link
-              </label>
-              <input
-                className="input"
-                id="youtube"
-                type="text"
-                value={youtubeUrl}
-                onChange={(e) => setYoutubeUrl(e.target.value)}
-              />
-              <label className="label checkbox" htmlFor="isActive">
-                <input
-                  id="isActive"
-                  type="checkbox"
-                  checked={isActive}
-                  onChange={() => setIsActive(!isActive)}
-                />
+              <InputIsActive isActive={isActive} setIsActive={setIsActive}>
                 Show Release
-              </label>
+              </InputIsActive>
               <InputPasswordProtect
                 id="isPasswordProtected"
                 isProtected={isPasswordProtected}

--- a/components/Releases/UpdateRelease.jsx
+++ b/components/Releases/UpdateRelease.jsx
@@ -284,7 +284,7 @@ export default function UpdateRelease({
             {namesTaken.message}
           </small>
 
-          <InputReleaseType type={type} setType={setType} />
+          <InputReleaseType type={type} onChange={setType} />
 
           <label className="label" htmlFor="yumUrl">
             Redemption Link
@@ -300,8 +300,7 @@ export default function UpdateRelease({
           <InputSocialSites
             sites={sites}
             setSites={setSites}
-            isSubscribed={profileData.is_subscribed}
-            isDlcmFriend={profileData.dlcm_friend}
+            hasProAccount={profileData.is_subscribed || profileData.dlcm_friend}
           />
           {profileData.is_subscribed || profileData.dlcm_friend ? (
             <>

--- a/components/UpdateProfile/UpdateProfile.jsx
+++ b/components/UpdateProfile/UpdateProfile.jsx
@@ -252,6 +252,7 @@ export default function UpdateProfile({
             setSites={setSites}
             isSubscribed={profileData.is_subscribed}
             isDlcmFriend={profileData.dlcm_friend}
+            showPersonal={true}
           />
           {profileData.is_subscribed || profileData.dlcm_friend ? (
             <InputPasswordProtect

--- a/components/UpdateProfile/UpdateProfile.jsx
+++ b/components/UpdateProfile/UpdateProfile.jsx
@@ -250,8 +250,11 @@ export default function UpdateProfile({
           <InputSocialSites
             sites={sites}
             setSites={setSites}
-            isSubscribed={profileData.is_subscribed}
-            isDlcmFriend={profileData.dlcm_friend}
+            hasProAccount={profileData.is_subscribed || profileData.dlcm_friend}
+            labelArtist={
+              profileData.type.charAt(0).toUpperCase() +
+              profileData.type.slice(1)
+            }
             showPersonal={true}
           />
           {profileData.is_subscribed || profileData.dlcm_friend ? (

--- a/components/UpdateProfile/UpdateProfile.jsx
+++ b/components/UpdateProfile/UpdateProfile.jsx
@@ -13,6 +13,7 @@ import PopoverTip from "../PopoverTip/PopoverTip"
 import Link from "next/link"
 import { prependProtocol } from "@/utils/utils"
 import InputPasswordProtect from "../InputPasswordProtect/InputPasswordProtect"
+import InputSocialSites from "../InputSocialSites/InputSocialSites"
 
 export default function UpdateProfile({
   getProfile,
@@ -38,21 +39,7 @@ export default function UpdateProfile({
     color: "transparent",
     message: "",
   })
-  const [bandcampUrl, setBandcampUrl] = useState(
-    profileData.sites.bandcamp ?? null
-  )
-  const [appleMusicUrl, setAppleMusicUrl] = useState(
-    profileData.sites.apple ?? null
-  )
-  const [spotifyUrl, setSpotifyUrl] = useState(
-    profileData.sites.spotify ?? null
-  )
-  const [soundcloudUrl, setSoundcloudUrl] = useState(
-    profileData.sites.soundcloud ?? null
-  )
-  const [youtubeUrl, setYoutubeUrl] = useState(
-    profileData.sites.youtube ?? null
-  )
+  const [sites, setSites] = useState(profileData.sites ?? null)
 
   const checkName = async (e) => {
     e.preventDefault()
@@ -96,13 +83,7 @@ export default function UpdateProfile({
         avatar_url: avatarUrl,
         avatar_path: newImagePath ? newImagePath : imagePath,
         slug: sluggedName,
-        sites: {
-          bandcamp: bandcampUrl ? prependProtocol(bandcampUrl) : null,
-          apple: appleMusicUrl ? prependProtocol(appleMusicUrl) : null,
-          spotify: spotifyUrl ? prependProtocol(spotifyUrl) : null,
-          soundcloud: soundcloudUrl ? prependProtocol(soundcloudUrl) : null,
-          youtube: youtubeUrl ? prependProtocol(youtubeUrl) : null,
-        },
+        sites: sites,
         page_password: pagePassword,
         is_password_protected: isPasswordProtected,
         yum_url: prependProtocol(yumUrl),
@@ -266,73 +247,24 @@ export default function UpdateProfile({
             This is the link your customers will visit to redeem their code. It
             is usually <code>your-name.bandcamp/yum</code>
           </small>
-          <label className="label" htmlFor="bandcamp">
-            Bandcamp Link
-          </label>
-          <input
-            className="input"
-            id="bandcamp"
-            type="text"
-            value={bandcampUrl}
-            onChange={(e) => setBandcampUrl(e.target.value)}
+          <InputSocialSites
+            sites={sites}
+            setSites={setSites}
+            isSubscribed={profileData.is_subscribed}
+            isDlcmFriend={profileData.dlcm_friend}
           />
           {profileData.is_subscribed || profileData.dlcm_friend ? (
-            <>
-              <label className="label" htmlFor="apple">
-                Apple Music Link
-              </label>
-              <input
-                className="input"
-                id="apple"
-                type="text"
-                value={appleMusicUrl}
-                onChange={(e) => setAppleMusicUrl(e.target.value)}
-              />
-
-              <label className="label" htmlFor="spotify">
-                Spotify Link
-              </label>
-              <input
-                className="input"
-                id="spotify"
-                type="text"
-                value={spotifyUrl}
-                onChange={(e) => setSpotifyUrl(e.target.value)}
-              />
-
-              <label className="label" htmlFor="soundcloud">
-                Soundcloud Link
-              </label>
-              <input
-                className="input"
-                id="soundcloud"
-                type="text"
-                value={soundcloudUrl}
-                onChange={(e) => setSoundcloudUrl(e.target.value)}
-              />
-
-              <label className="label" htmlFor="youtube">
-                YouTube Link
-              </label>
-              <input
-                className="input"
-                id="youtube"
-                type="text"
-                value={youtubeUrl}
-                onChange={(e) => setYoutubeUrl(e.target.value)}
-              />
-              <InputPasswordProtect
-                id="isPasswordProtected"
-                isProtected={isPasswordProtected}
-                pagePassword={pagePassword}
-                setIsProtected={() =>
-                  setIsPasswordProtected(!isPasswordProtected)
-                }
-                setPagePassword={(e) => setPagePassword(e.target.value)}
-              >
-                Password protect your profile page
-              </InputPasswordProtect>
-            </>
+            <InputPasswordProtect
+              id="isPasswordProtected"
+              isProtected={isPasswordProtected}
+              pagePassword={pagePassword}
+              setIsProtected={() =>
+                setIsPasswordProtected(!isPasswordProtected)
+              }
+              setPagePassword={(e) => setPagePassword(e.target.value)}
+            >
+              Password protect your profile page
+            </InputPasswordProtect>
           ) : null}
         </div>
         <footer className="button-actions cluster">


### PR DESCRIPTION
This PR will refactor the crud operations for user profiles and releases into separate components.

It also expands upon the release types.

Added a value called personal to sites. When updating your profile, you can now input your website and it will make your profile picture a link that goes to your personal website.