### PR TITLE
Fix/release filter

### DIFF
--- a/components/Profile/Profile.jsx
+++ b/components/Profile/Profile.jsx
@@ -52,6 +52,7 @@ export default function ProfileLayout({
       const newOffset = (e.selected * releasesPerPage) % releases.length
       setReleasesOffset(newOffset)
       setPageChange(e.selected)
+      filtersRef.current?.scrollIntoView({ behavior: "smooth" })
     },
     [releases.length]
   )

--- a/components/Releases/Releases.jsx
+++ b/components/Releases/Releases.jsx
@@ -15,11 +15,12 @@ export default function Releases({ profileData, getProfile }) {
   const user = useUser()
   const [addedNewRelease, setAddedNewRelease] = useState(false)
   const [releases, setReleases] = useState(profileData.releases)
+  const [refinedReleases, setRefinedReleases] = useState(profileData.releases)
   const [pageChange, setPageChange] = useState(0)
   const pageCount = Math.ceil(releases?.length / releasesPerPage)
   const [releasesOffset, setReleasesOffset] = useState(0)
   const endOffset = releasesOffset + releasesPerPage
-  const currentReleases = releases.slice(releasesOffset, endOffset)
+  const currentReleases = refinedReleases.slice(releasesOffset, endOffset)
 
   const handlePageClick = () => {
     filtersRef.current?.scrollIntoView({ behavior: "smooth" })
@@ -37,7 +38,7 @@ export default function Releases({ profileData, getProfile }) {
 
   const handleFilterRefinement = useCallback(
     (releases) => {
-      setReleases(releases)
+      setRefinedReleases(releases)
       handlePageChange({ selected: 0 })
     },
     [handlePageChange]
@@ -59,6 +60,7 @@ export default function Releases({ profileData, getProfile }) {
           isVisible={profileData.is_subscribed || profileData.dlcm_friend}
           releases={releases}
           onRefinement={handleFilterRefinement}
+          ref={filtersRef}
         />
       </header>
 

--- a/pages/reset-password.js
+++ b/pages/reset-password.js
@@ -67,7 +67,7 @@ export default function ResetPassword() {
         >
           <h1>Password Updated</h1>
           <p>Please log in to access your dashboard.</p>
-          <Link href="/">Log In</Link>
+          <Link href="/login">Log In</Link>
         </div>
       ) : (
         <div


### PR DESCRIPTION
This PR fixes the filter section on a user's dashboard. 

There was an issue: after filtering a user's releases on their dashboard, the filter option would disappear. This has been resolved.