### PR TITLE
Removes the scrollIntoView method on page load

### DIFF
--- a/components/Profile/Profile.jsx
+++ b/components/Profile/Profile.jsx
@@ -52,7 +52,6 @@ export default function ProfileLayout({
       const newOffset = (e.selected * releasesPerPage) % releases.length
       setReleasesOffset(newOffset)
       setPageChange(e.selected)
-      filtersRef.current?.scrollIntoView({ behavior: "smooth" })
     },
     [releases.length]
   )

--- a/components/Releases/Releases.jsx
+++ b/components/Releases/Releases.jsx
@@ -31,7 +31,6 @@ export default function Releases({ profileData, getProfile }) {
       const newOffset = (e.selected * releasesPerPage) % releases.length
       setReleasesOffset(newOffset)
       setPageChange(e.selected)
-      filtersRef.current?.scrollIntoView({ behavior: "smooth" })
     },
     [releases.length]
   )


### PR DESCRIPTION
When navigating to the dashboard or profile page, the page will automatically scroll releases into view when loaded. This seems like something had been reverted since that code was moved into a click handler for pagination changes. This PR removes that errant code.