### PR TITLE
Update card styles and fix grid alignment

### DIFF
--- a/components/Profile/Profile.jsx
+++ b/components/Profile/Profile.jsx
@@ -104,7 +104,7 @@ export default function ProfileLayout({
             onRefinement={handleFilterRefinement}
           />
 
-          <ul className="grid" role="list">
+          <ul className={cn(styles.cards, "grid")} role="list">
             {currentReleases.map((release, index) =>
               release.is_active ? (
                 <li key={index}>

--- a/components/Profile/Profile.module.css
+++ b/components/Profile/Profile.module.css
@@ -16,7 +16,12 @@
   grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
 }
 
+.cards li {
+  display: grid;
+}
+
 .release {
+  display: grid;
   text-decoration: none;
   color: var(--text-1);
 }

--- a/components/ReleaseFilter/ReleaseFilter.jsx
+++ b/components/ReleaseFilter/ReleaseFilter.jsx
@@ -24,7 +24,8 @@ export default function ReleaseFilter({ releases, onChange }) {
       </label>
       <select
         id="filter"
-        className="input select"
+        className="input select truncate"
+        style={{ maxInlineSize: "300px" }}
         onChange={(e) => handleFilter(e.target.value)}
       >
         <option value="all" key="all">

--- a/components/Releases/ReleaseCard.jsx
+++ b/components/Releases/ReleaseCard.jsx
@@ -43,7 +43,7 @@ export default function ReleaseCard({
         />
         <div className={styles.details}>
           <div>
-            <h3 className={cn(styles.title, "text-2")}>
+            <h3 className={cn(styles.title, "line-clamp")}>
               {profileData ? (
                 <Link
                   className="link"
@@ -55,8 +55,12 @@ export default function ReleaseCard({
                 release.title
               )}
             </h3>
-            <div className={styles.artist}>{release.artist}</div>
-            <div className={styles.label}>{release.label}</div>
+            <div className={cn(styles.artist, "line-clamp")}>
+              {release.artist}
+            </div>
+            <div className={cn(styles.label, "line-clamp")}>
+              {release.label}
+            </div>
             {release.type && release.type != "Choose release type" ? (
               <div className={styles.type}>
                 <IconRecord aria-hidden="true" /> {release.type}

--- a/components/Releases/ReleaseCard.module.css
+++ b/components/Releases/ReleaseCard.module.css
@@ -20,14 +20,9 @@
 }
 
 .title {
-  display: inline;
   font-size: var(--step-2);
   font-weight: var(--font-weight-6);
   font-family: var(--font-main);
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
 }
 
 .title a {
@@ -62,21 +57,26 @@
   flex: 1 1 100%;
   display: grid;
   grid-template-columns: 1fr auto;
+  line-height: 1.2;
 }
 
 .details > * {
   grid-column: 1;
 }
 
-.title {
-  line-height: 1.2;
+.label {
+  margin-top: 0.2em;
+}
+
+.label,
+.type {
+  font-size: var(--font-size--1);
 }
 
 .type {
   display: flex;
   align-items: baseline;
   gap: 0.2em;
-  font-size: var(--font-size--1);
 }
 
 .type svg {

--- a/styles/utilities.css
+++ b/styles/utilities.css
@@ -10,3 +10,16 @@
 .visually-hidden {
   display: none;
 }
+
+.truncate {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.line-clamp {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: var(--line-clamp, 2);
+}


### PR DESCRIPTION
Temporary solution until I can rethink this layout a bit.

- Adds `truncation` for single line truncation. 
- Adds `line-clamp` for multiline truncation; Set `--line-clamp` to change which line to truncate on. Default is 2.
- Adjusts card typography a smidge.
- Ensures that all cards are same height in the case that one or more cards have grown larger in height.

### Testing

- Navigate to an artist with a release that grows in height. The one shared with the bug was https://deploy-preview-153--unrivaled-pie-1255ea.netlify.app/pinkdolphinmusic
- To test truncation, open dev tools, select the text in a release card, and add a wall of text. See that after 2 lines the release title, artist name, and label will all truncate.