### PR TITLE
fixed sorting options and added link on release page

### DIFF
--- a/components/ReleaseSort/ReleaseSort.jsx
+++ b/components/ReleaseSort/ReleaseSort.jsx
@@ -6,7 +6,13 @@ const sortByTitle = (a, b) => (a.title > b.title ? 1 : -1)
 const sortByArtist = (a, b) =>
   a.artist.toLowerCase() > b.artist.toLowerCase() ? 1 : -1
 
-const sortProfileOptions = [
+const sortOptions = [
+  {
+    label: "Recently Added",
+    value: "newest",
+    method: sortByCreatedAt,
+    direction: "desc",
+  },
   {
     label: "Release Date (newest)",
     value: "release date (newest)",
@@ -20,57 +26,53 @@ const sortProfileOptions = [
     direction: "asc",
   },
   {
-    label: "A to Z (release)",
-    value: "a-z (release)",
+    label: "Release (a - z)",
+    value: "release (a - z)",
     method: sortByTitle,
     direction: "asc",
   },
   {
-    label: "Z to A (release)",
-    value: "z-a (release)",
+    label: "Release (z - a)",
+    value: "release (z - a)",
     method: sortByTitle,
     direction: "desc",
   },
   {
-    label: "A to Z (artist)",
-    value: "a-z (artist)",
+    label: "Artist (a - z)",
+    value: "artist (a - z)",
     method: sortByArtist,
     direction: "asc",
   },
   {
-    label: "Z to A (artist)",
-    value: "z-a (artist)",
+    label: "Artist (z - a)",
+    value: "artist (z - a)",
     method: sortByArtist,
     direction: "desc",
   },
 ]
 
-const sortDashboardOptions = [
-  {
-    label: "Newest First",
-    value: "newest",
-    method: sortByCreatedAt,
-    direction: "desc",
-  },
-  {
-    label: "Oldest First",
-    value: "oldest",
-    method: sortByCreatedAt,
-    direction: "asc",
-  },
-  ...sortProfileOptions,
-]
+// const sortDashboardOptions = [
+//   {
+//     label: "Recently Added",
+//     value: "newest",
+//     method: sortByCreatedAt,
+//     direction: "desc",
+//   },
+//   {
+//     label: "Oldest First",
+//     value: "oldest",
+//     method: sortByCreatedAt,
+//     direction: "asc",
+//   },
+//   ...sortProfileOptions,
+// ]
 
 export default function ReleaseSort({ releases, onChange, isDashboard }) {
-  const [selected, setSelected] = useState(
-    isDashboard ? "newest" : "release date (newest)"
-  )
-
-  const options = isDashboard ? sortDashboardOptions : sortProfileOptions
+  const [selected, setSelected] = useState("newest")
 
   const handleChange = (e) => {
     const value = e.target.value
-    const selected = options.find((option) => option.value === value)
+    const selected = sortOptions.find((option) => option.value === value)
     let sortedItems = [...releases].sort(selected.method)
 
     if (selected.direction === "desc") {
@@ -81,9 +83,9 @@ export default function ReleaseSort({ releases, onChange, isDashboard }) {
     onChange(sortedItems)
   }
 
-  useEffect(() => {
-    setSelected(isDashboard ? "newest" : "release date (newest)")
-  }, [releases])
+  // useEffect(() => {
+  //   setSelected(isDashboard ? "newest" : "release date (newest)")
+  // }, [releases])
 
   return (
     <div>
@@ -96,7 +98,7 @@ export default function ReleaseSort({ releases, onChange, isDashboard }) {
         value={selected}
         onChange={handleChange}
       >
-        {options.map(({ label, value }) => (
+        {sortOptions.map(({ label, value }) => (
           <option value={value} key={value}>
             {label}
           </option>

--- a/components/Releases/ReleaseLayout.jsx
+++ b/components/Releases/ReleaseLayout.jsx
@@ -5,6 +5,7 @@ import styles from "./ReleaseLayout.module.css"
 import cn from "classnames"
 import Head from "next/head"
 import Image from "next/image"
+import Link from "next/link"
 import InputPagePassword from "../InputPagePassword/InputPagePassword"
 import SEO from "../SEO/SEO"
 import { sanitize } from "isomorphic-dompurify"
@@ -14,6 +15,8 @@ export default function ReleaseLayout({
   isSubscribed,
   isDlcmFriend,
   profileYumLink,
+  userType,
+  userSlug,
 }) {
   const [authorized, setAuthorized] = useState(!release.is_password_protected)
   const [releaseDate, setReleaseDate] = useState(new Date(release.release_date))
@@ -36,8 +39,20 @@ export default function ReleaseLayout({
         />
         <div>
           <h1 className={styles.title}>{release.title}</h1>
-          <p className={styles.artist}>{release.artist}</p>
-          <p className={styles.label}>{release.label}</p>
+          {userType == "artist" ? (
+            <Link href={`/${userSlug}`} className={styles.artist}>
+              {release.artist}
+            </Link>
+          ) : (
+            <p className={styles.artist}>{release.artist}</p>
+          )}
+          {userType == "label" ? (
+            <Link href={`/${userSlug}`} className={styles.label}>
+              {release.label}
+            </Link>
+          ) : (
+            <p className={styles.label}>{release.label}</p>
+          )}
           <p>
             {release.type == "Choose release type" ? null : release.type}{" "}
             {release.release_date ? `  — ${releaseDate.getFullYear()}` : null}

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -12,7 +12,7 @@ export async function getServerSideProps({ params }) {
     .eq("slug", slug)
     .eq("releases.codes.redeemed", false)
     .eq("releases.is_active", true)
-    .order("release_date", { foreignTable: "releases", ascending: false })
+    .order("created_at", { foreignTable: "releases", ascending: false })
     .single()
 
   if (profile === null) {

--- a/pages/[user]/[slug].js
+++ b/pages/[user]/[slug].js
@@ -6,7 +6,7 @@ export async function getServerSideProps({ params }) {
   let { user, slug } = params
   let { data: releaseInfo, error } = await supabase
     .from("profiles")
-    .select("is_subscribed, dlcm_friend, yum_url , releases(*)")
+    .select("is_subscribed, dlcm_friend, yum_url, type, slug, releases(*)")
     .eq("slug", user)
     .eq("releases.release_slug", slug)
     .single()
@@ -23,6 +23,8 @@ export default function ReleasePage({ releaseInfo }) {
       isSubscribed={releaseInfo.is_subscribed}
       isDlcmFriend={releaseInfo.dlcm_friend}
       profileYumLink={releaseInfo.yum_url}
+      userType={releaseInfo.type}
+      userSlug={releaseInfo.slug}
       release={releaseInfo.releases[0]}
     />
   ) : null


### PR DESCRIPTION
This PR fixes the sort issue and switches oldest/newest to just Recently added.

Also makes the owner of the release, whether its the artist or label, clickable to go back to user profile.