### PR TITLE
fixed meta-data and about section on release page

### DIFF
--- a/components/Releases/ReleaseLayout.jsx
+++ b/components/Releases/ReleaseLayout.jsx
@@ -26,8 +26,8 @@ export default function ReleaseLayout({
   return (
     <>
       <SEO
-        title={release.title}
-        description={`Download code page for ${release.title}`}
+        title={`${release.title} by ${release.artist}`}
+        description={`Get a download code for ${release.title}`}
       ></SEO>
       <div className={cn(styles.wrapper, "stack inline-max")}>
         <Image
@@ -74,10 +74,12 @@ export default function ReleaseLayout({
           isSubscribed={isSubscribed}
           isDlcmFriend={isDlcmFriend}
         />
-        <section
-          className={styles.about}
-          dangerouslySetInnerHTML={{ __html: sanitizedAbout }}
-        />
+        {sanitizedAbout ? (
+          <section
+            className={styles.about}
+            dangerouslySetInnerHTML={{ __html: sanitizedAbout }}
+          />
+        ) : null}
       </div>
     </>
   )


### PR DESCRIPTION
This PR updates the meta-data to be what is called out in issue #165 

Also implements conditional rendering of release about section as called out in #164 