### PR TITLE
fixed copy on pages and added twitter meta:data

### DIFF
--- a/components/Releases/CreateRelease.jsx
+++ b/components/Releases/CreateRelease.jsx
@@ -277,7 +277,7 @@ export default function CreateRelease({
           />
           <small class="hint">
             This is the link your customers will visit to redeem their code. It
-            is usually <code>your-name.bandcamp/yum</code>.
+            is usually <code>your-name.bandcamp.com/yum</code>.
           </small>
 
           <InputSocialSites

--- a/components/SEO/SEO.jsx
+++ b/components/SEO/SEO.jsx
@@ -20,6 +20,13 @@ export default function SEO({ title, description }) {
         key="description"
       />
       <meta property="og:image" content={metadata.ogImage} key="ogImage" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={pageTitle} />
+      <meta
+        name="twitter:description"
+        content={description || metadata.description}
+      />
+      <meta name="twitter:image" content={metadata.ogImage} />
     </Head>
   )
 }

--- a/components/SEO/SEO.jsx
+++ b/components/SEO/SEO.jsx
@@ -3,7 +3,7 @@ import Head from "next/head"
 const metadata = {
   title: "DLCM",
   description: "The definitive solution for download code management.",
-  ogImage: `${process.env.NEXT_PUBLIC_DLCM_URL}/og-image.png`,
+  ogImage: `${process.env.NEXT_PUBLIC_DLCM_URL}og-image.png`,
 }
 
 export default function SEO({ title, description }) {

--- a/components/UpdateProfile/UpdateProfile.jsx
+++ b/components/UpdateProfile/UpdateProfile.jsx
@@ -245,7 +245,7 @@ export default function UpdateProfile({
           />
           <small className="hint">
             This is the link your customers will visit to redeem their code. It
-            is usually <code>your-name.bandcamp/yum</code>
+            is usually <code>your-name.bandcamp.com/yum</code>
           </small>
           <InputSocialSites
             sites={sites}

--- a/pages/pricing.js
+++ b/pages/pricing.js
@@ -49,10 +49,10 @@ export default function Pricing() {
             <div className={styles.perks}>
               <ul role="list">
                 <li>Unlimited Releases</li>
-                <li>Custom URLs</li>
-                <li>Release Level URLs</li>
                 <li>Password Protected Pages</li>
-                <li>Turn Releases On/Off</li>
+                <li>Custom URLs for Profile and Releases</li>
+                <li>Add Copy to Release Pages</li>
+                <li>Make Releases Active/Inactive</li>
                 <li>Bandcamp CSV Code Upload</li>
                 <li>Social/Streaming Links</li>
               </ul>


### PR DESCRIPTION
This PR fixes the copy on update profile and create release to show - yourname.bandcamp.com/yum

Also adds ability to write release page copy to pricing page.

Also adds twitter metadata