### PR TITLE
fixed delete release

### DIFF
--- a/components/Releases/UpdateRelease.jsx
+++ b/components/Releases/UpdateRelease.jsx
@@ -193,12 +193,13 @@ export default function UpdateRelease({
         if (codeError) throw error
         if (releaseError) throw error
         alert("Release deleted.")
+        setOpen(false)
+        resetForm()
       } catch (error) {
         alert("Error deleting data!")
         console.log(error)
       } finally {
-        getReleases()
-        setOpen(false)
+        getProfile()
       }
     } else {
       alert("Incorrect input")


### PR DESCRIPTION
This PR fixes the issue where the update release dialog would stay on the screen after the deletion of the release. Also makes sure to reload page to remove release from page view.