### PR TITLE
Fix react-quill theming in dark mode

### DIFF
--- a/components/InputReleaseAbout/InputReleaseAbout.jsx
+++ b/components/InputReleaseAbout/InputReleaseAbout.jsx
@@ -1,6 +1,6 @@
 import dynamic from "next/dynamic"
-// import Quill from "react-quill"
 import "react-quill/dist/quill.snow.css"
+import styles from "./InputReleaseAbout.module.css"
 
 const QuillNoSSRWrapper = dynamic(import("react-quill"), {
   ssr: false,
@@ -23,6 +23,38 @@ export default function InputReleaseAbout({ about, setAbout }) {
       <label htmlFor="about" className="label">
         About this release
       </label>
+      <style>
+        {`
+          .ql-container {
+            font: inherit;
+            border-radius: 0 0 var(--radius-1) var(--radius-1);
+          }
+
+          .ql-toolbar {
+            border-radius: var(--radius-1) var(--radius-1) 0 0;
+          }
+
+          .ql-toolbar.ql-snow,
+          .ql-container.ql-snow {
+            border: var(--border-size-1) solid var(--surface-4);
+            box-shadow: var(--shadow-1);
+          }
+
+          .ql-snow .ql-fill,
+          .ql-snow .ql-stroke.ql-fill {
+            fill: currentColor !important;
+          }
+
+          .ql-snow .ql-stroke {
+            stroke: currentColor !important;
+            fill: none !important;
+          }
+
+          .ql-snow.ql-toolbar button:hover, .ql-snow .ql-toolbar button:hover, .ql-snow.ql-toolbar button:focus, .ql-snow .ql-toolbar button:focus, .ql-snow.ql-toolbar button.ql-active, .ql-snow .ql-toolbar button.ql-active, .ql-snow.ql-toolbar .ql-picker-label:hover, .ql-snow .ql-toolbar .ql-picker-label:hover, .ql-snow.ql-toolbar .ql-picker-label.ql-active, .ql-snow .ql-toolbar .ql-picker-label.ql-active, .ql-snow.ql-toolbar .ql-picker-item:hover, .ql-snow .ql-toolbar .ql-picker-item:hover, .ql-snow.ql-toolbar .ql-picker-item.ql-selected, .ql-snow .ql-toolbar .ql-picker-item.ql-selected {
+            color: var(--text-2);
+          }
+        `}
+      </style>
 
       <QuillNoSSRWrapper
         modules={modules}

--- a/components/InputReleaseAbout/InputReleaseAbout.jsx
+++ b/components/InputReleaseAbout/InputReleaseAbout.jsx
@@ -1,6 +1,5 @@
 import dynamic from "next/dynamic"
 import "react-quill/dist/quill.snow.css"
-import styles from "./InputReleaseAbout.module.css"
 
 const QuillNoSSRWrapper = dynamic(import("react-quill"), {
   ssr: false,


### PR DESCRIPTION
The "about this release" editor has very poor color contrast when a user has the "dark" theme selected.

<img width="300" alt="Screenshot 2023-09-04 at 10 02 51 AM" src="https://github.com/frankmarra/DLCM/assets/1704038/10ebee5a-8091-496f-8282-adbf058e6f2d">

This PR will override some of the base `quill.snow.css` styles so that icons and text are themed appropriately. This is far from being the prettiest solution, but it fixes the bug for the time being.