### PR TITLE
Pagination Update

### DIFF
--- a/components/Profile/Profile.jsx
+++ b/components/Profile/Profile.jsx
@@ -2,7 +2,7 @@ import ReleaseCard from "@/components/Releases/ReleaseCard"
 import styles from "./Profile.module.css"
 import cn from "classnames"
 import SocialSites from "../SocialSites/SocialSites"
-import { useState, useRef, useCallback } from "react"
+import { useState, useRef, useCallback, useEffect } from "react"
 import Head from "next/head"
 import Link from "next/link"
 import Pagination from "../Pagination/Pagination"
@@ -11,8 +11,11 @@ import ReleaseRefinement from "../ReleaseRefinement/ReleaseRefinement"
 import InputPagePassword from "../InputPagePassword/InputPagePassword"
 import SEO from "../SEO/SEO"
 import { sanitize } from "isomorphic-dompurify"
+import Loader from "@/components/Loader/Loader"
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs"
 
 export default function ProfileLayout({
+  userId,
   avatar,
   name,
   location,
@@ -25,16 +28,24 @@ export default function ProfileLayout({
   isSubscribed,
   isDlcmFriend,
 }) {
+  const supabase = createClientComponentClient()
   const releasesPerPage = 10
   const filtersRef = useRef(null)
+  const [loading, setLoading] = useState(true)
   const [pageChange, setPageChange] = useState(0)
   const [authorized, setAuthorized] = useState(!isPasswordProtected)
-  const [refinedReleases, setRefinedReleases] = useState(releases)
-  const pageCount = Math.ceil(refinedReleases.length / releasesPerPage)
-  const [releasesOffset, setReleasesOffset] = useState(0)
-  const endOffset = releasesOffset + releasesPerPage
-  const currentReleases = refinedReleases.slice(releasesOffset, endOffset)
+  // const [refinedReleases, setRefinedReleases] = useState(releases)
+  // const pageCount = Math.ceil(refinedReleases.length / releasesPerPage)
+  const pageCount = Math.ceil(releases / releasesPerPage)
 
+  const [releasesOffset, setReleasesOffset] = useState(0)
+  // const endOffset = releasesOffset + releasesPerPage
+  // const currentReleases = refinedReleases.slice(releasesOffset, endOffset)
+  const [currentReleases, setCurrentReleases] = useState([])
+  const [currentSort, setCurrentSort] = useState({
+    sortBy: "created_at",
+    ascending: true,
+  })
   const sanitizedAbout = sanitize(aboutBlurb)
 
   const profilePic = (
@@ -47,101 +58,145 @@ export default function ProfileLayout({
     />
   )
 
+  useEffect(() => {
+    getReleases()
+  }, [releasesOffset, currentSort])
+
+  const getReleases = async () => {
+    try {
+      setLoading(true)
+      const endOffset = releasesOffset + releasesPerPage
+
+      let { data, error, status } = await supabase
+        .from("releases")
+        .select("*, codes(count)")
+        .eq("user_id", userId)
+        .eq("is_active", true)
+
+        .order(currentSort ? currentSort.sortBy : "created_at", {
+          ascending: currentSort ? currentSort.ascending : false,
+        })
+        .range(releasesOffset, endOffset - 1)
+
+      if (error && status !== 406) {
+        throw error
+      }
+
+      if (data) {
+        setCurrentReleases(data)
+      }
+    } catch (error) {
+      alert("Error loading user data!")
+      console.log(error)
+    } finally {
+      setLoading(false)
+    }
+  }
+
   const handlePageClick = () => {
     filtersRef.current?.scrollIntoView({ behavior: "smooth" })
   }
 
   const handlePageChange = useCallback(
     (e) => {
-      const newOffset = (e.selected * releasesPerPage) % releases.length
+      const newOffset = (e.selected * releasesPerPage) % releases
       setReleasesOffset(newOffset)
       setPageChange(e.selected)
     },
-    [releases.length]
+    [releases]
   )
 
   const handleFilterRefinement = useCallback(
-    (releases) => {
+    (sort) => {
       // console.log(releases[0].title)
-      setRefinedReleases(releases)
+      setCurrentSort(sort)
       handlePageChange({ selected: 0 })
     },
     [handlePageChange]
   )
 
+  // if (loading) {
+  //   return <Loader style={{ margin: "auto" }} />
+  // }
+
   return (
-    <>
-      <SEO
-        title={name}
-        description={`Discover download codes for music releases by ${name}`}
-      ></SEO>
-      <div className={cn(styles.wrapper, "stack inline-max")}>
-        {sites.personal ? (
-          <Link href={sites.personal}>{profilePic}</Link>
-        ) : (
-          profilePic
-        )}
-        <div className={cn(styles.info, "stack")}>
-          <h1 className={cn(styles.name, "text-3")}>{name}</h1>
-          <p className={cn(styles.location, "text-2")}>{location}</p>
-          {
-            // <p className={cn(styles.blurb)}>{aboutBlurb}</p>
-          }
-          {sanitizedAbout && authorized ? (
-            <section
-              className={styles.about}
-              dangerouslySetInnerHTML={{ __html: sanitizedAbout }}
+    currentReleases && (
+      <>
+        <SEO
+          title={name}
+          description={`Discover download codes for music releases by ${name}`}
+        ></SEO>
+        <div className={cn(styles.wrapper, "stack inline-max")}>
+          {sites.personal ? (
+            <Link href={sites.personal}>{profilePic}</Link>
+          ) : (
+            profilePic
+          )}
+          <div className={cn(styles.info, "stack")}>
+            <h1 className={cn(styles.name, "text-3")}>{name}</h1>
+            <p className={cn(styles.location, "text-2")}>{location}</p>
+            {
+              // <p className={cn(styles.blurb)}>{aboutBlurb}</p>
+            }
+            {sanitizedAbout && authorized ? (
+              <section
+                className={styles.about}
+                dangerouslySetInnerHTML={{ __html: sanitizedAbout }}
+              />
+            ) : null}
+            <SocialSites
+              sites={sites}
+              isSubscribed={isSubscribed}
+              isDlcmFriend={isDlcmFriend}
             />
-          ) : null}
-          <SocialSites
-            sites={sites}
-            isSubscribed={isSubscribed}
-            isDlcmFriend={isDlcmFriend}
-          />
+          </div>
         </div>
-      </div>
 
-      {!authorized ? (
-        <InputPagePassword
-          setAuthorized={setAuthorized}
-          pagePassword={pagePassword}
-        />
-      ) : (
-        <>
-          <ReleaseRefinement
-            ref={filtersRef}
-            releases={releases}
-            isVisible={isSubscribed || isDlcmFriend}
-            onRefinement={handleFilterRefinement}
+        {!authorized ? (
+          <InputPagePassword
+            setAuthorized={setAuthorized}
+            pagePassword={pagePassword}
           />
-
-          <ul className={cn(styles.cards, "grid")} role="list">
-            {currentReleases.map((release, index) =>
-              release.is_active ? (
-                <li key={index}>
-                  <Link
-                    className={styles.release}
-                    href={`/${profileSlug}/${release.release_slug}`}
-                  >
-                    <ReleaseCard
-                      key={release.id}
-                      release={release}
-                      profileSlug={profileSlug}
-                    />
-                  </Link>
-                </li>
-              ) : null
+        ) : (
+          <>
+            <ReleaseRefinement
+              ref={filtersRef}
+              releases={currentReleases}
+              isVisible={isSubscribed || isDlcmFriend}
+              onRefinement={handleFilterRefinement}
+            />
+            {loading ? (
+              <Loader style={{ margin: "auto" }} />
+            ) : (
+              <ul className={cn(styles.cards, "grid")} role="list">
+                {currentReleases.map((release, index) =>
+                  release.is_active ? (
+                    <li key={index}>
+                      <Link
+                        className={styles.release}
+                        href={`/${profileSlug}/${release.release_slug}`}
+                      >
+                        <ReleaseCard
+                          key={release.id}
+                          release={release}
+                          profileSlug={profileSlug}
+                        />
+                      </Link>
+                    </li>
+                  ) : null
+                )}
+              </ul>
             )}
-          </ul>
-          <Pagination
-            className={styles.pagination}
-            forcePage={pageChange}
-            onClick={handlePageClick}
-            onPageChange={handlePageChange}
-            pageCount={pageCount}
-          />
-        </>
-      )}
-    </>
+            <Pagination
+              className={styles.pagination}
+              forcePage={pageChange}
+              onClick={handlePageClick}
+              onPageChange={handlePageChange}
+              pageCount={pageCount}
+            />
+          </>
+        )}
+      </>
+    )
   )
 }

--- a/components/Profile/Profile.jsx
+++ b/components/Profile/Profile.jsx
@@ -37,7 +37,6 @@ export default function ProfileLayout({
   const [authorized, setAuthorized] = useState(!isPasswordProtected)
   // const [refinedReleases, setRefinedReleases] = useState(releases)
   // const pageCount = Math.ceil(refinedReleases.length / releasesPerPage)
-  const pageCount = Math.ceil(releases / releasesPerPage)
 
   const [releasesOffset, setReleasesOffset] = useState(0)
   // const endOffset = releasesOffset + releasesPerPage
@@ -48,6 +47,7 @@ export default function ProfileLayout({
     ascending: true,
   })
   const [currentFilter, setCurrentFilter] = useState("all")
+  let pageCount = Math.ceil(releases / releasesPerPage)
   const sanitizedAbout = sanitize(aboutBlurb)
 
   const profilePic = (
@@ -71,9 +71,10 @@ export default function ProfileLayout({
 
       let filteredReleases = supabase
         .from("releases")
-        .select("*, codes(count)")
+        .select("*, codes(count)", { count: "exact" })
         .eq("user_id", userId)
         .eq("is_active", true)
+        .eq("codes.redeemed", false)
         .order(currentSort ? currentSort.sortBy : "created_at", {
           ascending: currentSort ? currentSort.ascending : false,
         })

--- a/components/ReleaseFilter/ReleaseFilter.jsx
+++ b/components/ReleaseFilter/ReleaseFilter.jsx
@@ -1,16 +1,20 @@
 const sortByName = (a, b) => (a.toLowerCase() > b.toLowerCase() ? 1 : -1)
 
-export default function ReleaseFilter({ releases, onChange }) {
+export default function ReleaseFilter({ releases, artistNames, onChange }) {
   const artists = [
-    ...new Map(releases.map(({ artist }) => [artist, artist])).values(),
+    ...new Map(artistNames.map(({ artist }) => [artist, artist])).values(),
   ].sort(sortByName)
 
+  // const handleFilter = (value) => {
+  //   if (value == "all") {
+  //     onChange(releases)
+  //   } else {
+  //     onChange(releases.filter(({ artist }) => artist === value))
+  //   }
+  // }
+
   const handleFilter = (value) => {
-    if (value == "all") {
-      onChange(releases)
-    } else {
-      onChange(releases.filter(({ artist }) => artist === value))
-    }
+    onChange(value)
   }
 
   if (artists.length <= 1) {

--- a/components/ReleaseRefinement/ReleaseRefinement.jsx
+++ b/components/ReleaseRefinement/ReleaseRefinement.jsx
@@ -3,10 +3,10 @@ import ReleaseFilter from "../ReleaseFilter/ReleaseFilter"
 import ReleaseSort from "../ReleaseSort/ReleaseSort"
 
 function ReleaseRefinement(
-  { isVisible, onRefinement, releases, isDashboard },
+  { isVisible, onRefinement, releases, artists, isDashboard },
   ref
 ) {
-  const [filtered, setFiltered] = useState(releases)
+  const [filtered, setFiltered] = useState(artists)
   const [sortType, setSortType] = useState()
 
   // useEffect(() => {
@@ -14,8 +14,8 @@ function ReleaseRefinement(
   // }, [filtered])
 
   useEffect(() => {
-    onRefinement(sortType)
-  }, [sortType])
+    onRefinement(sortType, filtered)
+  }, [sortType, filtered])
 
   if (!isVisible) {
     return
@@ -27,7 +27,11 @@ function ReleaseRefinement(
       className="cluster"
       style={{ "--cluster-gap": "var(--size-3)" }}
     >
-      <ReleaseFilter releases={releases} onChange={setFiltered} />
+      <ReleaseFilter
+        artistNames={artists}
+        releases={releases}
+        onChange={setFiltered}
+      />
       <ReleaseSort onChange={setSortType} />
     </div>
   )

--- a/components/ReleaseRefinement/ReleaseRefinement.jsx
+++ b/components/ReleaseRefinement/ReleaseRefinement.jsx
@@ -7,15 +7,15 @@ function ReleaseRefinement(
   ref
 ) {
   const [filtered, setFiltered] = useState(releases)
-  const [sorted, setSorted] = useState(filtered)
+  const [sortType, setSortType] = useState()
+
+  // useEffect(() => {
+  //   setSorted(filtered)
+  // }, [filtered])
 
   useEffect(() => {
-    setSorted(filtered)
-  }, [filtered])
-
-  useEffect(() => {
-    onRefinement(sorted)
-  }, [sorted])
+    onRefinement(sortType)
+  }, [sortType])
 
   if (!isVisible) {
     return
@@ -28,11 +28,7 @@ function ReleaseRefinement(
       style={{ "--cluster-gap": "var(--size-3)" }}
     >
       <ReleaseFilter releases={releases} onChange={setFiltered} />
-      <ReleaseSort
-        releases={filtered}
-        onChange={setSorted}
-        isDashboard={isDashboard}
-      />
+      <ReleaseSort onChange={setSortType} />
     </div>
   )
 }

--- a/components/ReleaseRefinement/ReleaseRefinement.jsx
+++ b/components/ReleaseRefinement/ReleaseRefinement.jsx
@@ -6,8 +6,11 @@ function ReleaseRefinement(
   { isVisible, onRefinement, releases, artists, isDashboard },
   ref
 ) {
-  const [filtered, setFiltered] = useState(artists)
-  const [sortType, setSortType] = useState()
+  const [filtered, setFiltered] = useState("all")
+  const [sortType, setSortType] = useState({
+    sortBy: "created_at",
+    ascending: true,
+  })
 
   // useEffect(() => {
   //   setSorted(filtered)

--- a/components/ReleaseSort/ReleaseSort.jsx
+++ b/components/ReleaseSort/ReleaseSort.jsx
@@ -10,44 +10,51 @@ const sortOptions = [
   {
     label: "Recently Added",
     value: "newest",
-    method: sortByCreatedAt,
-    direction: "desc",
+
+    ascending: false,
+    sortBy: "created_at",
   },
   {
     label: "Release Date (newest)",
     value: "release date (newest)",
-    method: sortByReleaseDate,
-    direction: "desc",
+
+    ascending: false,
+    sortBy: "release_date",
   },
   {
     label: "Release Date (oldest)",
     value: "release date (oldest)",
-    method: sortByReleaseDate,
-    direction: "asc",
+
+    ascending: true,
+    sortBy: "release_date",
   },
   {
     label: "Release (a - z)",
     value: "release (a - z)",
-    method: sortByTitle,
-    direction: "asc",
+
+    ascending: true,
+    sortBy: "title",
   },
   {
     label: "Release (z - a)",
     value: "release (z - a)",
-    method: sortByTitle,
-    direction: "desc",
+
+    ascending: false,
+    sortBy: "title",
   },
   {
     label: "Artist (a - z)",
     value: "artist (a - z)",
-    method: sortByArtist,
-    direction: "asc",
+
+    ascending: true,
+    sortBy: "artist",
   },
   {
     label: "Artist (z - a)",
     value: "artist (z - a)",
-    method: sortByArtist,
-    direction: "desc",
+
+    ascending: false,
+    sortBy: "artist",
   },
 ]
 
@@ -73,14 +80,14 @@ export default function ReleaseSort({ releases, onChange, isDashboard }) {
   const handleChange = (e) => {
     const value = e.target.value
     const selected = sortOptions.find((option) => option.value === value)
-    let sortedItems = [...releases].sort(selected.method)
+    // let sortedItems = [...releases].sort(selected.method)
 
-    if (selected.direction === "desc") {
-      sortedItems.reverse()
-    }
+    // if (selected.direction === "desc") {
+    //   sortedItems.reverse()
+    // }
 
     setSelected(value)
-    onChange(sortedItems)
+    onChange(selected)
   }
 
   // useEffect(() => {

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -6,13 +6,14 @@ export async function getServerSideProps({ params }) {
   let { slug } = params
   let { data: profile, error } = await supabase
     .from("profiles")
+    // .select(
+    //   "avatar_url, username, location, slug, sites, page_password, is_password_protected, about_blurb, is_subscribed, dlcm_friend, releases(*, codes(count))"
+    // )
     .select(
-      "avatar_url, username, location, slug, sites, page_password, is_password_protected, about_blurb, is_subscribed, dlcm_friend, releases(*, codes(count))"
+      "id, avatar_url, username, location, slug, sites, page_password, is_password_protected, about_blurb, is_subscribed, dlcm_friend, releases(count)"
     )
     .eq("slug", slug)
-    .eq("releases.codes.redeemed", false)
     .eq("releases.is_active", true)
-    .order("created_at", { foreignTable: "releases", ascending: false })
     .single()
 
   if (profile === null) {
@@ -24,10 +25,11 @@ export async function getServerSideProps({ params }) {
 export default function ProfilePage({ profile }) {
   return profile ? (
     <ProfileLayout
+      userId={profile.id}
       avatar={profile.avatar_url}
       name={profile.username}
       location={profile.location}
-      releases={profile.releases}
+      releases={profile.releases[0].count}
       profileSlug={profile.slug}
       sites={profile.sites}
       pagePassword={profile.page_password}

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -16,13 +16,20 @@ export async function getServerSideProps({ params }) {
     .eq("releases.is_active", true)
     .single()
 
+  let { data: artists, error: artistsError } = await supabase
+    .from("profiles")
+    .select("releases(artist)")
+    .eq("slug", slug)
+    .eq("releases.is_active", true)
+    .single()
+
   if (profile === null) {
     return { props: {}, redirect: { destination: "/404" } }
   }
-  return { props: { profile } }
+  return { props: { profile, artists } }
 }
 
-export default function ProfilePage({ profile }) {
+export default function ProfilePage({ profile, artists }) {
   return profile ? (
     <ProfileLayout
       userId={profile.id}
@@ -30,6 +37,7 @@ export default function ProfilePage({ profile }) {
       name={profile.username}
       location={profile.location}
       releases={profile.releases[0].count}
+      artists={artists.releases}
       profileSlug={profile.slug}
       sites={profile.sites}
       pagePassword={profile.page_password}


### PR DESCRIPTION
This PR will update the pagination to be done on the server side. Previously, all user releases were pulled on initial page visit. This caused some users to not be able to have their pages load due to large data return sizes. This will now be solved using Supabase pagination. Each time a user clicks to a new page or changes filter/sorting options, a new db call is performed to fetch the new set of releases.

So far, this is only implemented on the public facing profiles.